### PR TITLE
Add typedef for ssize_t

### DIFF
--- a/snappy-stubs-internal.h
+++ b/snappy-stubs-internal.h
@@ -486,6 +486,9 @@ inline char* string_as_array(string* str) {
   return str->empty() ? NULL : &*str->begin();
 }
 
+// Windows doesn't have ssize_t, so create one in the namespace snappy
+typedef std::make_signed<size_t>::type ssize_t;
+
 }  // namespace snappy
 
 #endif  // UTIL_SNAPPY_OPENSOURCE_SNAPPY_STUBS_INTERNAL_H_


### PR DESCRIPTION
MSVC doesn't have ssize_t, so add a typedef in snappy-stube-internal.h.
This makes MSVC builds compile out of the box without requiring config.h
or autotools.
