### PR TITLE
Provide pkg-config data

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,5 +19,8 @@ noinst_PROGRAMS = $(TESTS)
 EXTRA_DIST = autogen.sh testdata/alice29.txt testdata/asyoulik.txt testdata/baddata1.snappy testdata/baddata2.snappy testdata/baddata3.snappy testdata/geo.protodata testdata/fireworks.jpeg testdata/html testdata/html_x_4 testdata/kppkn.gtb testdata/lcet10.txt testdata/paper-100k.pdf testdata/plrabn12.txt testdata/urls.10K
 dist_doc_DATA = ChangeLog COPYING INSTALL NEWS README format_description.txt framing_format.txt
 
+pkgconfigdir = $(libdir)/pkgconfig
+nodist_pkgconfig_DATA = snappy.pc
+
 libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck

--- a/configure.ac
+++ b/configure.ac
@@ -129,5 +129,5 @@ AC_SUBST([SNAPPY_PATCHLEVEL])
 AC_SUBST([SNAPPY_LTVERSION], snappy_ltversion)
 
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_FILES([Makefile snappy-stubs-public.h])
+AC_CONFIG_FILES([Makefile snappy-stubs-public.h snappy.pc])
 AC_OUTPUT

--- a/snappy.pc.in
+++ b/snappy.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE@
+Description: A fast compression/decompression library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -l@PACKAGE@
+Cflags: -I${includedir}


### PR DESCRIPTION
I would like to have an ability to obtain snappy include paths with pkg-config