### PR TITLE
Update google-code links in README.md

### DIFF
--- a/README
+++ b/README
@@ -67,7 +67,7 @@ Usage
 
 Note that Snappy, both the implementation and the main interface,
 is written in C++. However, several third-party bindings to other languages
-are available; see the Google Code page at http://code.google.com/p/snappy/
+are available; see https://google.github.io/snappy/
 for more information. Also, if you want to use Snappy from C code, you can
 use the included C bindings in snappy-c.h.
 
@@ -102,12 +102,12 @@ tests to verify you have not broken anything. Note that if you have the
 Google Test library installed, unit test behavior (especially failures) will be
 significantly more user-friendly. You can find Google Test at
 
-  http://code.google.com/p/googletest/
+  https://github.com/google/googletest
 
 You probably also want the gflags library for handling of command-line flags;
 you can find it at
 
-  http://code.google.com/p/google-gflags/
+  https://github.com/gflags/gflags
 
 In addition to the unit tests, snappy contains microbenchmarks used to
 tune compression and decompression performance. These are automatically run
@@ -132,4 +132,4 @@ Contact
 Snappy is distributed through Google Code. For the latest version, a bug tracker,
 and other information, see
 
-  http://code.google.com/p/snappy/
+  https://github.com/google/snappy


### PR DESCRIPTION
Also, you could update the link in the https://github.com/google/snappy description field from https://code.google.com/p/snappy/ to https://google.github.io/snappy/

I have another question which I'm asking here because there are no 'Issues' on github/google/snappy:

I'm adding CMake support to snappy. Let me know if you're willing to accept a PR about this.