### PR TITLE
Fix compilation warning

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1333,7 +1333,7 @@ class SnappySinkAllocator {
   void Flush(size_t size) {
     size_t size_written = 0;
     size_t block_size;
-    for (int i = 0; i < blocks_.size(); ++i) {
+    for (size_t i = 0; i < blocks_.size(); ++i) {
       block_size = min<size_t>(blocks_[i].size, size - size_written);
       dest_->AppendAndTakeOwnership(blocks_[i].data, block_size,
                                     &SnappySinkAllocator::Deleter, NULL);


### PR DESCRIPTION
```
snappy.cc: In member function ‘void snappy::SnappySinkAllocator::Flush(size_t)’:
snappy.cc:1336:38: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < blocks_.size(); ++i) {
```
This warning doesn't shows with current compilation options, but it does when you compile snappy with -Wall flag.
