### PR TITLE
Add instructions in README.md to build Snappy for iOS

### DIFF
--- a/README
+++ b/README
@@ -133,3 +133,12 @@ Snappy is distributed through Google Code. For the latest version, a bug tracker
 and other information, see
 
   http://code.google.com/p/snappy/
+
+
+Snappy for iOS
+==============
+
+Not official project to build snappy for iOS platform, see
+
+  https://github.com/ideawu/snappy-ios
+


### PR DESCRIPTION
I was not expecting this PR to be merged, but since Issues is closed for this project, I submit this PR, in case others who want to find "Snappy for iOS" will see this message, and goto [snappy-ios](https://github.com/ideawu/snappy-ios) and find out what he needs.

The  [snappy-ios](https://github.com/ideawu/snappy-ios) project is manually updated to this official Snappy project. What it does is offer a Makefile and necessary .h files, users only need to run `make` on Mac OS X, then a `libsnappy.a` will be ready for he to use for iOS project.