### PR TITLE
Add #ifdef around definition of DISALLOW_COPY_AND_ASSIGN.

### DIFF
--- a/snappy-stubs-public.h.in
+++ b/snappy-stubs-public.h.in
@@ -80,9 +80,11 @@ typedef unsigned long long uint64;
 
 typedef std::string string;
 
+#ifndef DISALLOW_COPY_AND_ASSIGN
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&);               \
-  void operator=(const TypeName&)
+  TypeName(const TypeName&) = delete;      \
+  void operator=(const TypeName&) = delete
+#endif
 
 #if !@ac_cv_have_sys_uio_h@
 // Windows does not have an iovec type, yet the concept is universally useful.

--- a/snappy-stubs-public.h.in
+++ b/snappy-stubs-public.h.in
@@ -82,8 +82,8 @@ typedef std::string string;
 
 #ifndef DISALLOW_COPY_AND_ASSIGN
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&) = delete;      \
-  void operator=(const TypeName&) = delete
+  TypeName(const TypeName&);               \
+  void operator=(const TypeName&)
 #endif
 
 #if !@ac_cv_have_sys_uio_h@


### PR DESCRIPTION
This prevents macro redefinition errors when other Google projects (e.g. Chromium) attempt to use Snappy.