### PR TITLE
Revert "Improve zippy decompression speed."

### DIFF
--- a/snappy-stubs-internal.h
+++ b/snappy-stubs-internal.h
@@ -225,20 +225,6 @@ inline void UNALIGNED_STORE64(void *p, uint64 v) {
 
 #endif
 
-// This can be more efficient than UNALIGNED_LOAD64 + UNALIGNED_STORE64
-// on some platforms, in particular ARM.
-inline void UnalignedCopy64(const void *src, void *dst) {
-  if (sizeof(void *) == 8) {
-    UNALIGNED_STORE64(dst, UNALIGNED_LOAD64(src));
-  } else {
-    const char *src_char = reinterpret_cast<const char *>(src);
-    char *dst_char = reinterpret_cast<char *>(dst);
-
-    UNALIGNED_STORE32(dst_char, UNALIGNED_LOAD32(src_char));
-    UNALIGNED_STORE32(dst_char + 4, UNALIGNED_LOAD32(src_char + 4));
-  }
-}
-
 // The following guarantees declaration of the byte swap functions.
 #ifdef WORDS_BIGENDIAN
 

--- a/snappy.cc
+++ b/snappy.cc
@@ -89,7 +89,9 @@ size_t MaxCompressedLength(size_t source_len) {
 namespace {
 
 void UnalignedCopy64(const void* src, void* dst) {
-  memcpy(dst, src, 8);
+  uint64 tmp;
+  memcpy(&tmp, src, 8);
+  memcpy(dst, &tmp, 8);
 }
 
 void UnalignedCopy128(const void* src, void* dst) {


### PR DESCRIPTION
This reverts commit 8bfb028b618747a6ac8af159c87e9196c729566f.

The commit 8bfb028 (Improve zippy decompression speed) introduce a crash
when snappy is compiled with _FORTIFY_SOURCE with musl libc. Backtrace
reveals that it it comes from using memcpy with overlap. Since this may
have security implications we better revert it for now.

Bactrace from core dump created with `make check`:
````
(gdb) bt
 #0  memcpy (__n=8, __os=0xb38c8367eea, __od=0xb38c8367eeb)
     at /usr/include/fortify/string.h:48
 #1  snappy::(anonymous namespace)::UnalignedCopy64 (src=0xb38c8367eea,
     dst=0xb38c8367eeb) at snappy.cc:92
 #2  0x00006fb4c7c31717 in snappy::(anonymous namespace)::IncrementalCopy
 (
     buf_limit=0xb38c8380ee0 "", op_limit=<optimized out>, op=<optimized
 out>,
     src=0xb38c8367eea " .\001") at snappy.cc:178
 #3  snappy::SnappyArrayWriter::AppendFromSelf (len=<optimized out>,
     offset=<optimized out>, this=<synthetic pointer>) at snappy.cc:1131
 #4
 snappy::SnappyDecompressor::DecompressAllTags<snappy::SnappyArrayWriter>
 (
     writer=<synthetic pointer>, this=0x7f1d26737050) at snappy.cc:715
 #5  snappy::InternalUncompressAllTags<snappy::SnappyArrayWriter> (
     uncompressed_len=<optimized out>, writer=<synthetic pointer>,
     decompressor=0x7f1d26737050) at snappy.cc:799
 #6  snappy::InternalUncompress<snappy::SnappyArrayWriter> (
     writer=<synthetic pointer>, r=0x7f1d26737000) at snappy.cc:789
 #7  snappy::RawUncompress (compressed=compressed@entry=0x7f1d267370c0,
     uncompressed=0xb38c8367ee0 "  content: .\001") at snappy.cc:1149
 #8  0x00006fb4c7c3194d in snappy::RawUncompress (compressed=<optimized
 out>,
     n=<optimized out>, uncompressed=<optimized out>) at snappy.cc:1144
 #9  0x00000b38c5c6261a in snappy::BM_UFlat (iters=99, arg=<optimized
 out>)
     at snappy_unittest.cc:1371
 #10 0x00000b38c5c69846 in snappy::Benchmark::Run (this=0xb38c8323c40)
     at snappy-test.cc:192
 #11 0x00000b38c5c5f3fd in RunSpecifiedBenchmarks () at snappy-test.h:485
 #12 main (argc=1, argv=0x7f1d267374b8) at snappy_unittest.cc:1515
````
