### PR TITLE
Use ARCH_K8 on ppc64le

### DIFF
--- a/snappy-internal.h
+++ b/snappy-internal.h
@@ -80,8 +80,8 @@ char* CompressFragment(const char* input,
 // Does not read *(s1 + (s2_limit - s2)) or beyond.
 // Requires that s2_limit >= s2.
 //
-// Separate implementation for x86_64, for speed.  Uses the fact that
-// x86_64 is little endian.
+// Separate implementation for x86_64 and ppc64le, for speed.
+// Uses the fact that both are little endian.
 #if defined(ARCH_K8)
 static inline std::pair<size_t, bool> FindMatchLength(const char* s1,
                                                       const char* s2,

--- a/snappy-stubs-internal.h
+++ b/snappy-stubs-internal.h
@@ -47,8 +47,8 @@
 
 #include "snappy-stubs-public.h"
 
-#if defined(__x86_64__)
-
+#if defined(__x86_64__) || \
+    (defined(__powerpc64__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
 // Enable 64-bit optimized versions of some routines.
 #define ARCH_K8 1
 


### PR DESCRIPTION
The optimised x86_64 FindMatchLength also works well on ppc64le.

This gives us some pretty big wins on compression:
 - html and html4 speed up by ~17%
 - urls speed up by ~9%
 - pdf speeds up by ~25%
 - pb speeds up by  ~20%

Signed-off-by: Daniel Axtens <dja@axtens.net>