### PR TITLE
Update index.html to include MongoDB

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
 <p>Snappy is used or is available as an alternative in software such as</p>
 
 <ul>
+<li><a href="https://www.mongodb.com/">MongoDB</a></li>
 <li><a href="http://cassandra.apache.org/">Cassandra</a></li>
 <li><a href="http://www.couchbase.com/">Couchbase</a></li>
 <li><a href="http://hadoop.apache.org/">Hadoop</a></li>


### PR DESCRIPTION
MongoDB is using Snappy compression by default in its wiredTiger storage engine. I think it's worth mentioning (https://docs.mongodb.com/manual/core/wiredtiger/#compression)