### PR TITLE
Include sys/uio.h in check headers.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_LANG([C++])
 AC_C_BIGENDIAN
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
-AC_CHECK_HEADERS([stdint.h stddef.h sys/mman.h sys/resource.h windows.h byteswap.h sys/byteswap.h sys/endian.h sys/time.h])
+AC_CHECK_HEADERS([stdint.h stddef.h sys/uio.h sys/mman.h sys/resource.h windows.h byteswap.h sys/byteswap.h sys/endian.h sys/time.h])
 
 # Don't use AC_FUNC_MMAP, as it checks for mappings of already-mapped memory,
 # which we don't need (and does not exist on Windows).


### PR DESCRIPTION
Without checking `sys/uio.h`, `ac_cv_have_sys_uio_h` will always be **0** @ [snappy-stubs-public.h.in#L47](https://github.com/google/snappy/blob/master/snappy-stubs-public.h.in#L47)