### PR TITLE
Fixed comparison between signed and unsigned integer expressions in s…

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1336,7 +1336,7 @@ class SnappyScatteredWriter {
     char* const op_end = op_ptr_ + len;
     // See SnappyArrayWriter::AppendFromSelf for an explanation of
     // the "offset - 1u" trick.
-    if (PREDICT_TRUE(offset - 1u < op_ptr_ - op_base_ && op_end <= op_limit_)) {
+    if (PREDICT_TRUE(offset - 1u < unsigned(op_ptr_ - op_base_) && op_end <= op_limit_)) {
       // Fast path: src and dst in current block.
       op_ptr_ = IncrementalCopy(op_ptr_ - offset, op_ptr_, op_end, op_limit_);
       return true;
@@ -1423,7 +1423,7 @@ class SnappySinkAllocator {
   void Flush(size_t size) {
     size_t size_written = 0;
     size_t block_size;
-    for (int i = 0; i < blocks_.size(); ++i) {
+    for (unsigned int i = 0; i < blocks_.size(); ++i) {
       block_size = std::min<size_t>(blocks_[i].size, size - size_written);
       dest_->AppendAndTakeOwnership(blocks_[i].data, block_size,
                                     &SnappySinkAllocator::Deleter, NULL);


### PR DESCRIPTION
There was some comparison between signed and unsigned integer expressions in snappy.cc. The for loop would never reach end in larges blocks_
```
/bin/bash ./libtool  --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H -I.   -Wall  -g -O2 -MT snappy.lo -MD -MP -MF .deps/snappy.Tpo -c -o snappy.lo snappy.cc
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -Wall -g -O2 -MT snappy.lo -MD -MP -MF .deps/snappy.Tpo -c snappy.cc  -fPIC -DPIC -o .libs/snappy.o
snappy.cc: In member function ‘void snappy::SnappySinkAllocator::Flush(size_t)’:
***snappy.cc:1426:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < blocks_.size(); ++i) {
                     ~~^~~~~~~~~~~~~~~~***
In file included from snappy-internal.h:34:0,
                 from snappy.cc:30:
snappy.cc: In instantiation of ‘bool snappy::SnappyScatteredWriter<Allocator>::AppendFromSelf(size_t, size_t) [with Allocator = snappy::SnappySinkAllocator; size_t = long unsigned int]’:
snappy.cc:730:13:   required from ‘void snappy::SnappyDecompressor::DecompressAllTags(Writer*) [with Writer = snappy::SnappyScatteredWriter<snappy::SnappySinkAllocator>]’
snappy.cc:819:3:   required from ‘bool snappy::InternalUncompressAllTags(snappy::SnappyDecompressor*, Writer*, snappy::uint32, snappy::uint32) [with Writer = snappy::SnappyScatteredWriter<snappy::SnappySinkAllocator>; snappy::uint32 = unsigned int]’
snappy.cc:1485:54:   required from here
**snappy.cc:1339:34: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (PREDICT_TRUE(offset - 1u < op_ptr_ - op_base_ && op_end <= op_limit_)) {
                      ~~~~~~~~~~~~^~~~~~~~~~~~~**
snappy-stubs-internal.h:73:46: note: in definition of macro ‘PREDICT_TRUE’
 #define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
```