### PR TITLE
Fixed comparison between signed and unsigned integer expressions in s…

### DIFF
--- a/snappy_unittest.cc
+++ b/snappy_unittest.cc
@@ -848,7 +848,7 @@ TEST(Snappy, FourByteOffset) {
   }
   AppendCopy(&compressed, src.size(), fragment1.size());
   src += fragment1;
-  CHECK_EQ(length, src.size());
+  CHECK_EQ(unsigned(length), src.size());
 
   string uncompressed;
   CHECK(snappy::IsValidCompressedBuffer(compressed.data(), compressed.size()));
@@ -867,7 +867,7 @@ TEST(Snappy, IOVecEdgeCases) {
   static const int kLengths[] = { 2, 1, 4, 8, 128 };
 
   struct iovec iov[ARRAYSIZE(kLengths)];
-  for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {
+  for (unsigned int i = 0; i < ARRAYSIZE(kLengths); ++i) {
     iov[i].iov_base = new char[kLengths[i]];
     iov[i].iov_len = kLengths[i];
   }
@@ -919,7 +919,7 @@ TEST(Snappy, IOVecEdgeCases) {
   CHECK_EQ(0, memcmp(iov[3].iov_base, "23123123", 8));
   CHECK_EQ(0, memcmp(iov[4].iov_base, "123bc12", 7));
 
-  for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {
+  for (unsigned int i = 0; i < ARRAYSIZE(kLengths); ++i) {
     delete[] reinterpret_cast<char *>(iov[i].iov_base);
   }
 }
@@ -928,7 +928,7 @@ TEST(Snappy, IOVecLiteralOverflow) {
   static const int kLengths[] = { 3, 4 };
 
   struct iovec iov[ARRAYSIZE(kLengths)];
-  for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {
+  for (unsigned int i = 0; i < ARRAYSIZE(kLengths); ++i) {
     iov[i].iov_base = new char[kLengths[i]];
     iov[i].iov_len = kLengths[i];
   }
@@ -941,7 +941,7 @@ TEST(Snappy, IOVecLiteralOverflow) {
   CHECK(!snappy::RawUncompressToIOVec(
       compressed.data(), compressed.size(), iov, ARRAYSIZE(iov)));
 
-  for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {
+  for (unsigned int i = 0; i < ARRAYSIZE(kLengths); ++i) {
     delete[] reinterpret_cast<char *>(iov[i].iov_base);
   }
 }
@@ -950,7 +950,7 @@ TEST(Snappy, IOVecCopyOverflow) {
   static const int kLengths[] = { 3, 4 };
 
   struct iovec iov[ARRAYSIZE(kLengths)];
-  for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {
+  for (unsigned int i = 0; i < ARRAYSIZE(kLengths); ++i) {
     iov[i].iov_base = new char[kLengths[i]];
     iov[i].iov_len = kLengths[i];
   }
@@ -964,7 +964,7 @@ TEST(Snappy, IOVecCopyOverflow) {
   CHECK(!snappy::RawUncompressToIOVec(
       compressed.data(), compressed.size(), iov, ARRAYSIZE(iov)));
 
-  for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {
+  for (unsigned int i = 0; i < ARRAYSIZE(kLengths); ++i) {
     delete[] reinterpret_cast<char *>(iov[i].iov_base);
   }
 }
@@ -1168,7 +1168,7 @@ TEST(Snappy, FindMatchLengthRandom) {
     DataEndingAtUnreadablePage u(s);
     DataEndingAtUnreadablePage v(t);
     int matched = TestFindMatchLength(u.data(), v.data(), t.size());
-    if (matched == t.size()) {
+    if (unsigned(matched) == t.size()) {
       EXPECT_EQ(s, t);
     } else {
       EXPECT_NE(s[matched], t[matched]);
@@ -1354,7 +1354,7 @@ static void BM_UFlat(int iters, int arg) {
 
   // Pick file to process based on "arg"
   CHECK_GE(arg, 0);
-  CHECK_LT(arg, ARRAYSIZE(files));
+  CHECK_LT(unsigned(arg), ARRAYSIZE(files));
   string contents = ReadTestDataFile(files[arg].filename,
                                      files[arg].size_limit);
 
@@ -1380,7 +1380,7 @@ static void BM_UValidate(int iters, int arg) {
 
   // Pick file to process based on "arg"
   CHECK_GE(arg, 0);
-  CHECK_LT(arg, ARRAYSIZE(files));
+  CHECK_LT(unsigned(arg), ARRAYSIZE(files));
   string contents = ReadTestDataFile(files[arg].filename,
                                      files[arg].size_limit);
 
@@ -1403,7 +1403,7 @@ static void BM_UIOVec(int iters, int arg) {
 
   // Pick file to process based on "arg"
   CHECK_GE(arg, 0);
-  CHECK_LT(arg, ARRAYSIZE(files));
+  CHECK_LT(unsigned(arg), ARRAYSIZE(files));
   string contents = ReadTestDataFile(files[arg].filename,
                                      files[arg].size_limit);
 
@@ -1417,7 +1417,7 @@ static void BM_UIOVec(int iters, int arg) {
   int used_so_far = 0;
   for (int i = 0; i < kNumEntries; ++i) {
     iov[i].iov_base = dst + used_so_far;
-    if (used_so_far == contents.size()) {
+    if (unsigned(used_so_far) == contents.size()) {
       iov[i].iov_len = 0;
       continue;
     }
@@ -1449,7 +1449,7 @@ static void BM_UFlatSink(int iters, int arg) {
 
   // Pick file to process based on "arg"
   CHECK_GE(arg, 0);
-  CHECK_LT(arg, ARRAYSIZE(files));
+  CHECK_LT(unsigned(arg), ARRAYSIZE(files));
   string contents = ReadTestDataFile(files[arg].filename,
                                      files[arg].size_limit);
 
@@ -1481,7 +1481,7 @@ static void BM_ZFlat(int iters, int arg) {
 
   // Pick file to process based on "arg"
   CHECK_GE(arg, 0);
-  CHECK_LT(arg, ARRAYSIZE(files));
+  CHECK_LT(unsigned(arg), ARRAYSIZE(files));
   string contents = ReadTestDataFile(files[arg].filename,
                                      files[arg].size_limit);
 


### PR DESCRIPTION
There was some comparison between signed and unsigned integer expressions in snappy_unittests.cc. 
```
g++ -DHAVE_CONFIG_H -I.    -Wall  -g -O2 -MT snappy_unittest-snappy_unittest.o -MD -MP -MF .deps/snappy_unittest-snappy_unittest.Tpo -c -o snappy_unittest-snappy_unittest.o `test -f 'snappy_unittest.cc' || echo './'`snappy_unittest.cc
In file included from snappy-internal.h:34:0,
                 from snappy_unittest.cc:39:
snappy_unittest.cc: In function ‘void snappy::Test_Snappy_FourByteOffset()’:
snappy-test.h:579:41: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
 #define CHECK_EQ(a, b) CRASH_UNLESS((a) == (b))
                                     ~~~~^~~~~~
snappy-stubs-internal.h:73:46: note: in definition of macro ‘PREDICT_TRUE’
 #define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
                                              ^
snappy-test.h:579:24: note: in expansion of macro ‘CRASH_UNLESS’
 #define CHECK_EQ(a, b) CRASH_UNLESS((a) == (b))
                        ^~~~~~~~~~~~
**snappy_unittest.cc:851:3: note: in expansion of macro ‘CHECK_EQ’
   CHECK_EQ(length, src.size());**
   ^~~~~~~~
snappy_unittest.cc: In function ‘void snappy::Test_Snappy_IOVecEdgeCases()’:
**snappy_unittest.cc:870:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {**
                      
**snappy_unittest.cc:922:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {**
                      
snappy_unittest.cc: In function ‘void snappy::Test_Snappy_IOVecLiteralOverflow()’:
**snappy_unittest.cc:931:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {**
                      
**snappy_unittest.cc:944:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {**
                      
snappy_unittest.cc: In function ‘void snappy::Test_Snappy_IOVecCopyOverflow()’:
**snappy_unittest.cc:953:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {**
                      
**snappy_unittest.cc:967:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < ARRAYSIZE(kLengths); ++i) {**
                      
snappy_unittest.cc: In function ‘void snappy::Test_Snappy_FindMatchLengthRandom()’:
**snappy_unittest.cc:1171:17: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (matched == t.size()) {**
         ~~~~~~~~^~~~~~~~~~~
In file included from snappy-internal.h:34:0,
                 from snappy_unittest.cc:39:
snappy_unittest.cc: In function ‘void snappy::BM_UFlat(int, int)’:
snappy-test.h:581:41: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                                     ~~~~^~~~~
snappy-stubs-internal.h:73:46: note: in definition of macro ‘PREDICT_TRUE’
 #define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
                                              ^
snappy-test.h:581:24: note: in expansion of macro ‘CRASH_UNLESS’
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                        ^~~~~~~~~~~~
**snappy_unittest.cc:1357:3: note: in expansion of macro ‘CHECK_LT’
   CHECK_LT(arg, ARRAYSIZE(files));**
   ^~~~~~~~
snappy_unittest.cc: In function ‘void snappy::BM_UValidate(int, int)’:
snappy-test.h:581:41: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                                     ~~~~^~~~~
snappy-stubs-internal.h:73:46: note: in definition of macro ‘PREDICT_TRUE’
 #define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
                                              ^
snappy-test.h:581:24: note: in expansion of macro ‘CRASH_UNLESS’
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                        ^~~~~~~~~~~~
**snappy_unittest.cc:1383:3: note: in expansion of macro ‘CHECK_LT’
   CHECK_LT(arg, ARRAYSIZE(files));**
   ^~~~~~~~
snappy_unittest.cc: In function ‘void snappy::BM_UIOVec(int, int)’:
snappy-test.h:581:41: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                                     ~~~~^~~~~
snappy-stubs-internal.h:73:46: note: in definition of macro ‘PREDICT_TRUE’
 #define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
                                              ^
snappy-test.h:581:24: note: in expansion of macro ‘CRASH_UNLESS’
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                        ^~~~~~~~~~~~
**snappy_unittest.cc:1406:3: note: in expansion of macro ‘CHECK_LT’
   CHECK_LT(arg, ARRAYSIZE(files));**
   ^~~~~~~~
snappy_unittest.cc:1420:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (used_so_far == contents.size()) {
         ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
In file included from snappy-internal.h:34:0,
                 from snappy_unittest.cc:39:
snappy_unittest.cc: In function ‘void snappy::BM_UFlatSink(int, int)’:
snappy-test.h:581:41: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                                     ~~~~^~~~~
snappy-stubs-internal.h:73:46: note: in definition of macro ‘PREDICT_TRUE’
 #define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
                                              ^
snappy-test.h:581:24: note: in expansion of macro ‘CRASH_UNLESS’
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                        ^~~~~~~~~~~~
**snappy_unittest.cc:1452:3: note: in expansion of macro ‘CHECK_LT’
   CHECK_LT(arg, ARRAYSIZE(files));**
   ^~~~~~~~
snappy_unittest.cc: In function ‘void snappy::BM_ZFlat(int, int)’:
snappy-test.h:581:41: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                                     ~~~~^~~~~
snappy-stubs-internal.h:73:46: note: in definition of macro ‘PREDICT_TRUE’
 #define PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
                                              ^
snappy-test.h:581:24: note: in expansion of macro ‘CRASH_UNLESS’
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
                        ^~~~~~~~~~~~
**snappy_unittest.cc:1484:3: note: in expansion of macro ‘CHECK_LT’
   CHECK_LT(arg, ARRAYSIZE(files));**
   ^~~~~~~~
```