### PR TITLE
fix a signed/unsigned comparison warning

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1423,7 +1423,7 @@ class SnappySinkAllocator {
   void Flush(size_t size) {
     size_t size_written = 0;
     size_t block_size;
-    for (int i = 0; i < blocks_.size(); ++i) {
+    for (size_t i = 0; i < blocks_.size(); ++i) {
       block_size = std::min<size_t>(blocks_[i].size, size - size_written);
       dest_->AppendAndTakeOwnership(blocks_[i].data, block_size,
                                     &SnappySinkAllocator::Deleter, NULL);


### PR DESCRIPTION
This fixes a minor error, where a signed integer is used to in a loop instead of a `size_t`. This fixes a compiler warning when building snappy.