### PR TITLE
Modify snappy test Windows.h include to not define windows specific min/max

### DIFF
--- a/snappy-test.cc
+++ b/snappy-test.cc
@@ -33,6 +33,7 @@
 #endif
 
 #ifdef HAVE_WINDOWS_H
+#define NOMINMAX
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
This was causing a compilation bug with VS 2017 Win64 as the Windows.h MAX macro conflicted with the use of std::max.