### PR TITLE
cmake: Add missing linking to GTEST_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ ENDIF (HAVE_LIBQUICKLZ)
 ADD_EXECUTABLE(snappy-unittest snappy_unittest.cc snappy-test.cc)
 TARGET_COMPILE_DEFINITIONS(snappy-unittest PRIVATE -DHAVE_CONFIG_H)
 TARGET_LINK_LIBRARIES(snappy-unittest snappy ${COMPRESSION_LIBS}
-                      ${GFLAGS_LIBRARIES})
+                      ${GFLAGS_LIBRARIES} ${GTEST_LIBRARIES})
 TARGET_INCLUDE_DIRECTORIES(snappy-unittest BEFORE PRIVATE ${Snappy_SOURCE_DIR}
                            ${GTEST_INCLUDE_DIRS} ${GFLAGS_INCLUDE_DIRS})
 


### PR DESCRIPTION
Since the snappy_unittest target uses gtest routines (when available), it needs to link to gtest explicitly. Otherwise, the build fails due to unavailable gtest symbols.

Note: I'm not interested in signing the CLA. The patch is trivial and goes under the same license as the package itself. You are free to pick it up, or someone else may take it over and submit as his own.