### PR TITLE
Error for missing README

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,4 +28,4 @@ libtool: $(LIBTOOL_DEPS)
 # Needed by autoconf because we use README.md instead of README.
 # See http://stackoverflow.com/q/15013672/
 README: README.md
-	cat $< > $@.tmp
+	cat $< > $@


### PR DESCRIPTION
Should not this rule produce README, instead of README.tmp? Otherwise, I receive the following error:

```
cat README.md > README.tmp
 /usr/bin/mkdir -p '/usr/src/tmp/package-snappy/usr/doc/snappy-1.1.5'
 /usr/bin/ginstall -c -m 644 ChangeLog COPYING INSTALL NEWS ./README format_description.txt framing_format.txt '/usr/src/tmp/package-snappy/usr/doc/snappy-1.1.5'
/usr/bin/ginstall: cannot stat './README': No such file or directory
Makefile:767: recipe for target 'install-dist_docDATA' failed
make[1]: *** [install-dist_docDATA] Error 1
make[1]: Leaving directory '/usr/src/tmp/snappy-1.1.5'
Makefile:1230: recipe for target 'install-am' failed
make: *** [install-am] Error 2
```