### PR TITLE
fix autoconf README.md workaround

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,4 +28,4 @@ libtool: $(LIBTOOL_DEPS)
 # Needed by autoconf because we use README.md instead of README.
 # See http://stackoverflow.com/q/15013672/
 README: README.md
-	cat $< > $@.tmp
+	cp $< $@


### PR DESCRIPTION
Autotools build appears to be broken right now, since at the install step it tries to install a nonexistent `README` file. https://github.com/google/snappy/commit/7d7a8ec805192a192dda1906280387b2c8665225 added a workaround, but it doesn't seem to work here. This minimal patch fixes the workaround to actually create `README`, instead of `README.tmp`. One could also probably easily configure autotools to just install `README.md`, but...whatever.

(I know that CMake is the future, but since you currently can't build a static library with it, might as well have autotools work as well.)