### PR TITLE
cmake: Add missing linking to GTEST_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,10 @@ if(SNAPPY_BUILD_TESTS)
       "${PROJECT_SOURCE_DIR}/snappy-test.cc"
   )
   target_compile_definitions(snappy_unittest PRIVATE -DHAVE_CONFIG_H)
-  target_link_libraries(snappy_unittest snappy ${GFLAGS_LIBRARIES})
+  target_link_libraries(snappy_unittest
+    snappy
+    ${GFLAGS_LIBRARIES}
+    ${GTEST_LIBRARIES})
 
   if(HAVE_LIBZ)
     target_link_libraries(snappy_unittest z)


### PR DESCRIPTION
Since the snappy_unittest target uses gtest routines (when available),
it needs to link to gtest explicitly. Otherwise, the build fails due
to unavailable gtest symbols.