### PR TITLE
distinguish library name for static build on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ set_target_properties(snappy
 target_compile_definitions(snappy PRIVATE -DHAVE_CONFIG_H)
 if(BUILD_SHARED_LIBS)
   set_target_properties(snappy PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+elseif(MSVC)
+  set_target_properties(snappy PROPERTIES OUTPUT_NAME snappy_static)
 endif(BUILD_SHARED_LIBS)
 
 if(SNAPPY_BUILD_TESTS)


### PR DESCRIPTION
On Windows, whether you build with `BUILD_SHARED_LIBS` or not, the library is still named `snappy.lib`. This is confusing compared to the Unix case, where it's `libsnappy.a` for static libs and `libsnappy.so` or `libsnappy.dylib` for dynamic libraries, and makes it impossible to install both a static and a dynamic lib at the same time.

This patch names the static library `snappy_static.lib` on Windows to avoid that.

It's maybe a little bit weird to have the default behavior not produce something named `snappy.lib`, but `snappy_static.lib` is the name that we've already shipped with in conda-forge for what that's worth.