### PR TITLE
Silence -Wdeprecated warning on clang

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1433,7 +1433,6 @@ bool SnappyScatteredWriter<Allocator>::SlowAppendFromSelf(size_t offset,
 class SnappySinkAllocator {
  public:
   explicit SnappySinkAllocator(Sink* dest): dest_(dest) {}
-  ~SnappySinkAllocator() {}
 
   char* Allocate(int size) {
     Datablock block(new char[size], size);


### PR DESCRIPTION
* definition of implicit copy constructor for 'SnappySinkAllocator'
  is deprecated because it has a user-declared destructor.