### PR TITLE
Fix stale information in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ test.)
 Contact
 =======
 
-Snappy is distributed through GitHub. For the latest version, a bug tracker,
+Snappy is distributed through GitHub. For the latest version
 and other information, see
 
   http://google.github.io/snappy/


### PR DESCRIPTION
Claims to link to a bug tracker, but there is none for this software.