### PR TITLE
In gcc __powerpc64__ not __ppc64__ defines the PPC64 architecture

### DIFF
--- a/snappy-stubs-internal.h
+++ b/snappy-stubs-internal.h
@@ -72,7 +72,7 @@
 // Enable 64-bit optimized versions of some routines.
 #define ARCH_K8 1
 
-#elif elif defined(__ppc__) || defined(__PPC__)
+#elif defined(__ppc__) || defined(__PPC__)
 
 #define ARCH_PPC 1
 

--- a/snappy-stubs-internal.h
+++ b/snappy-stubs-internal.h
@@ -72,7 +72,7 @@
 // Enable 64-bit optimized versions of some routines.
 #define ARCH_K8 1
 
-#elif defined(__ppc64__)
+#elif elif defined(__ppc__) || defined(__PPC__)
 
 #define ARCH_PPC 1
 


### PR DESCRIPTION
Corrects 18488d6212331fee647ecfded85353ab3ad91de8 and still maintains
clang compatibility (like the #27 originally).

Compiler tests:

$ uname -m
ppc64le
$  cat  /tmp/x.c

$ gcc -c /tmp/x.c
/tmp/x.c:3:2: warning: #warning __powerpc64__ exists [-Wcpp]
 #warning __powerpc64__ exists
  ^~~~~~~
/tmp/x.c:11:2: error: #error __ppc64__ not defined
 #error __ppc64__ not defined
  ^~~~~
$ clang  /tmp/x.c
/tmp/x.c:3:2: warning: __powerpc64__ exists [-W#warnings]
 ^
/tmp/x.c:9:2: warning: __ppc64__ exists [-W#warnings]
 ^
2 warnings generated.

I should be on the CLA list already.