### PR TITLE
Add R snappier package

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 <li><a href="http://code.google.com/p/php-snappy/">PHP</a></li>
 <li>
 <a href="http://pypi.python.org/pypi/python-snappy">Python</a> (including a command-line tool for the framing format)</li>
-<li><a href="https://github.com/lulyon/R-snappy">R</a></li>
+<li>R: <a href="https://github.com/HuwCampbell/snappier">snappier</a>, <a href="https://github.com/lulyon/R-snappy">R-snappy</a></li>
 <li><a href="https://github.com/miyucy/snappy">Ruby</a></li>
 <li><a href="https://github.com/BurntSushi/rust-snappy">Rust</a></li>
 <li>


### PR DESCRIPTION
I've added my package to the list for R, as
- it is a complete package on CRAN;
- it doesn't require any extra linking or building and;
- it doesn't suffer from runtime exceptions like the R-snappy package does when given specific inputs.