### PR TITLE
Update links in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,31 +24,31 @@ ports do (see below).
 Snappy is written in C++, but C bindings are included, and several bindings to
 other languages are maintained by third parties:
 
-* C#: [Snappy for .NET](http://snappy4net.codeplex.com/) (P/Invoke wrapper),
-  [Snappy.NET](http://snappy.angeloflogic.com/) (P/Invoke wrapper),
+* C#: [Snappy for .NET](https://archive.codeplex.com/?p=snappy4net) (P/Invoke wrapper),
+  [Snappy.NET](https://snappy.machinezoo.com/) (P/Invoke wrapper),
   [Snappy.Sharp](https://github.com/jeffesp/Snappy.Sharp) (native
   reimplementation)
-* [C port](http://github.com/andikleen/snappy-c)
-* [C++ MSVC packaging](http://snappy.angeloflogic.com/) (plus Windows binaries,
+* [C port](https://github.com/andikleen/snappy-c)
+* [C++ MSVC packaging](https://snappy.machinezoo.com/) (plus Windows binaries,
   NuGet packages and command-line tool)
-* Common Lisp: [Library bindings](http://flambard.github.com/thnappy/),
+* Common Lisp: [Library bindings](http://flambard.github.io/thnappy/),
   [native reimplementation](https://github.com/brown/snappy)
 * Erlang: [esnappy](https://github.com/thekvs/esnappy),
-  [snappy-erlang-nif](https://github.com/fdmanana/snappy-erlang-nif)
+  [snappy-erlang-nif](https://github.com/skunkwerks/snappy-erlang-nif)
 * [Go](https://github.com/golang/snappy/)
 * [Haskell](http://hackage.haskell.org/package/snappy)
-* [Haxe](https://github.com/MaddinXx/hxsnappy) (C++/Neko)
+* [Haxe](https://lib.haxe.org/p/snappy/) (C++/Neko)
 * [iOS packaging](https://github.com/ideawu/snappy-ios)
 * Java: [JNI wrapper](https://github.com/xerial/snappy-java) (including the
-  framing format), [native reimplementation](http://code.google.com/p/jsnappy/),
+  framing format), [native reimplementation](https://code.google.com/archive/p/jsnappy/),
   [other native reimplementation](https://github.com/dain/snappy) (including
   the framing format)
 * [Lua](https://github.com/forhappy/lua-snappy)
 * [Node.js](https://github.com/kesla/node-snappy) (including the [framing
   format](https://github.com/kesla/node-snappy-stream))
-* [Perl](http://search.cpan.org/dist/Compress-Snappy/)
+* [Perl](https://metacpan.org/release/Compress-Snappy)
 * [PHP](https://github.com/kjdev/php-ext-snappy)
-* [Python](http://pypi.python.org/pypi/python-snappy) (including a command-line
+* [Python](https://pypi.org/project/python-snappy/) (including a command-line
   tool for the framing format)
 * [R](https://github.com/lulyon/R-snappy)
 * [Ruby](https://github.com/miyucy/snappy)
@@ -59,14 +59,14 @@ Snappy is used or is available as an alternative in software such as
 
 * [MongoDB](https://www.mongodb.com/)
 * [Cassandra](http://cassandra.apache.org/)
-* [Couchbase](http://www.couchbase.com/)
+* [Couchbase](https://www.couchbase.com/)
 * [Hadoop](http://hadoop.apache.org/)
-* [LessFS](http://www.lessfs.com/wordpress/)
+* [LessFS](https://web.archive.org/web/20170121033506/http://www.lessfs.com:80/wordpress/)
 * [LevelDB](https://github.com/google/leveldb) (which is in turn used by
-  [Google Chrome](http://chrome.google.com/))
+  [Google Chrome](https://www.google.com/chrome/))
 * [Lucene](http://lucene.apache.org/)
-* [VoltDB](http://voltdb.com/)
+* [VoltDB](https://www.voltdb.com/)
 
 If you know of more, do not hesitate to let us know. The easiest way to get in
 touch is via the
-[Snappy discussion mailing list](http://groups.google.com/group/snappy-compression).
+[Snappy discussion mailing list](https://groups.google.com/forum/#!forum/snappy-compression).


### PR DESCRIPTION
Update the PyPI url, fixing point (a) raised in the discussion at
https://groups.google.com/d/topic/snappy-compression/iKpuTpTcjOI/discussion

Additionally, update many other urls, whether simply from http to https,
or reflecting various moves, or linking to archived versions for pages
that now give "404 Not Found" errors.