### PR TITLE
Fix a compile error when the HAVE_SYS_TIME_H flag is not set

### DIFF
--- a/snappy-test.cc
+++ b/snappy-test.cc
@@ -101,7 +101,7 @@ void StartBenchmarkTiming() {
   FILETIME dummy;
   CHECK(GetProcessTimes(
       GetCurrentProcess(), &dummy, &dummy, &dummy, &benchmark_start_cpu));
-#else
+#elif defined HAVE_SYS_TIME_H
   gettimeofday(&benchmark_start_real, NULL);
   if (getrusage(RUSAGE_SELF, &benchmark_start_cpu) == -1) {
     perror("getrusage(RUSAGE_SELF)");
@@ -141,7 +141,7 @@ void StopBenchmarkTiming() {
 
   benchmark_cpu_time_us +=
       (stop_ulargeint.QuadPart - start_ulargeint.QuadPart + 5) / 10;
-#else  // WIN32
+#elif defined HAVE_SYS_TIME_H
   struct timeval benchmark_stop_real;
   gettimeofday(&benchmark_stop_real, NULL);
   benchmark_real_time_us +=
@@ -158,7 +158,7 @@ void StopBenchmarkTiming() {
                                       benchmark_start_cpu.ru_utime.tv_sec);
   benchmark_cpu_time_us += (benchmark_stop_cpu.ru_utime.tv_usec -
                             benchmark_start_cpu.ru_utime.tv_usec);
-#endif  // WIN32
+#endif
 
   benchmark_running = false;
 }

--- a/snappy-test.h
+++ b/snappy-test.h
@@ -198,7 +198,7 @@ class CycleTimer {
   void Start() {
 #ifdef WIN32
     QueryPerformanceCounter(&start_);
-#else
+#elif defined HAVE_SYS_TIME_H
     gettimeofday(&start_, NULL);
 #endif
   }
@@ -213,7 +213,7 @@ class CycleTimer {
     double elapsed = static_cast<double>(stop.QuadPart - start_.QuadPart) /
         frequency.QuadPart;
     real_time_us_ += elapsed * 1e6 + 0.5;
-#else
+#elif defined HAVE_SYS_TIME_H
     struct timeval stop;
     gettimeofday(&stop, NULL);
 
@@ -230,7 +230,7 @@ class CycleTimer {
   int64 real_time_us_;
 #ifdef WIN32
   LARGE_INTEGER start_;
-#else
+#elif defined HAVE_SYS_TIME_H
   struct timeval start_;
 #endif
 };


### PR DESCRIPTION
As <sys/time.h> is guarded by HAVE_SYS_TIME_H, if the flag is missing,
gettimeofday will become an undefined identifier.