### PR TITLE
Added pkg-config file and .gitignore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(Snappy VERSION 1.1.7 LANGUAGES C CXX)
+
+set(SNAPPY_VER 1.1.7)
+
+project(Snappy VERSION ${SNAPPY_VER} LANGUAGES C CXX)
 
 # This project requires C++11.
 set(CMAKE_CXX_STANDARD 11)
@@ -106,6 +109,21 @@ configure_file(
   "${PROJECT_SOURCE_DIR}/cmake/config.h.in"
   "${PROJECT_BINARY_DIR}/config.h"
 )
+
+include(GNUInstallDirs)
+set(PKG_CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
+if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+    set(PKG_CONFIG_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+    set(PKG_CONFIG_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+    set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+else()
+    set(PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+    set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+endif(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/libsnappy.pc.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/libsnappy.pc")
 
 # We don't want to define HAVE_ macros in public headers. Instead, we use
 # CMake's variable substitution with 0/1 variables, which will be seen by the
@@ -253,3 +271,6 @@ install(
     "${PROJECT_BINARY_DIR}/SnappyConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Snappy"
 )
+
+install(FILES ${PROJECT_BINARY_DIR}/libsnappy.pc
+        DESTINATION ${INSTALL_PKGCONFIG_DIR})

--- a/cmake/libsnappy.pc.in
+++ b/cmake/libsnappy.pc.in
@@ -1,0 +1,10 @@
+prefix=@PKG_CONFIG_PREFIX@
+exec_prefix=@PKG_CONFIG_PREFIX@
+libdir=@PKG_CONFIG_LIBDIR@
+includedir=@PKG_CONFIG_INCLUDEDIR@
+
+Name: snappy
+Description: Fast compressor/decompressor library.
+Version: @SNAPPY_VER@
+Libs: -L@PKG_CONFIG_LIBDIR@ -lsnappy
+Cflags: -I@PKG_CONFIG_INCLUDEDIR@


### PR DESCRIPTION
This is a redo of https://github.com/google/snappy/pull/55, which had merge conflicts and seemed abandoned.

I implemented the suggested fix of using the variables provided by GNUInstallDirs

A notable difference is that the `snappy.pc` is now installed in `<prefix>/lib/pkgconfig` instead of `<prefix>/share/pkgconfig`, which seems to be more in line with the other packages installing libraries.

Grabbed the absolute/relative logic from https://github.com/rtrlib/rtrlib/pull/150; when building in Nixos, it overrides `GNUInstallDirs` to absolute paths, which _may_ not be in the prefix:

Verification using a relative `CMAKE_INSTALL_LIBDIR`:
```
$ cat libsnappy.pc
prefix=/usr/local
exec_prefix=/usr/local
libdir=${prefix}/lib
includedir=${prefix}/include

Name: snappy
Description: Fast compressor/decompressor library.
Version: 1.1.7
Libs: -L${prefix}/lib -lsnappy
Cflags: -I${prefix}/include
```

```
$ pkg-config libsnappy --libs
-L/usr/local/lib -lsnappy
$ pkg-config libsnappy --cflags
-I/usr/local/include
```

With an absolute `CMAKE_INSTALL_LIBDIR`, building with nix:
```
prefix=/nix/store/hknzbw87dnmz7zq0lf99vjf7bf2l2hps-snappy-1.1.7
exec_prefix=/nix/store/hknzbw87dnmz7zq0lf99vjf7bf2l2hps-snappy-1.1.7
libdir=/nix/store/hknzbw87dnmz7zq0lf99vjf7bf2l2hps-snappy-1.1.7/lib
includedir=/nix/store/z67qhiawswr2jq1p71r4f2987czx3slh-snappy-1.1.7-dev/include

Name: snappy
Description: Fast compressor/decompressor library.
Version: 1.1.7
Libs: -L/nix/store/hknzbw87dnmz7zq0lf99vjf7bf2l2hps-snappy-1.1.7/lib -lsnappy
Cflags: -I/nix/store/z67qhiawswr2jq1p71r4f2987czx3slh-snappy-1.1.7-dev/include
```
```
$ pkg-config libsnappy --libs
-L/nix/store/hknzbw87dnmz7zq0lf99vjf7bf2l2hps-snappy-1.1.7/lib -lsnappy
$ pkg-config libsnappy --cflags
-I/nix/store/z67qhiawswr2jq1p71r4f2987czx3slh-snappy-1.1.7-dev/include
```

Installing the [snappy gem](https://github.com/miyucy/snappy/blob/master/ext/extconf.rb) (i.e. it properly detected it and didn't recompile snappy):
```
$ time gem install snappy
Fetching snappy-0.0.17.gem
Building native extensions. This could take a while...
Successfully installed snappy-0.0.17
Parsing documentation for snappy-0.0.17
Installing ri documentation for snappy-0.0.17
Done installing documentation for snappy after 0 seconds
1 gem installed
gem install snappy  1.25s user 0.57s system 80% cpu 2.270 total
```
