### PR TITLE
Add more definitions to detect PPC64

### DIFF
--- a/snappy-stubs-internal.h
+++ b/snappy-stubs-internal.h
@@ -72,7 +72,7 @@
 // Enable 64-bit optimized versions of some routines.
 #define ARCH_K8 1
 
-#elif defined(__ppc64__)
+#elif defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__)
 
 #define ARCH_PPC 1
 


### PR DESCRIPTION
GCC uses `__PPC64__` not the lower-case version. Not sure about the origin of the lower-case version but I verified the existence of both `__PPC64__` and `__powerpc64__` on our system with GCC 8.3.0.

Note that this is an alternative version of https://github.com/google/snappy/pull/67.

IMO this is more suitable because by the usage of `ARCH_PPC` I assume that a 64 bit version is what is wanted, not a general "is PowerPC", see e.g. here: https://github.com/google/snappy/blob/3fcbc47f9976c880d1e915b1c7cf17633e70e772/snappy-internal.h#L92