### PR TITLE
Minimal changes to add reasonable support for POWER architecture 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,30 +69,12 @@ check_library_exists(z zlibVersion "" HAVE_LIBZ)
 check_library_exists(lzo2 lzo1x_1_15_compress "" HAVE_LIBLZO2)
 
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("/arch:AVX" HAVE_VISUAL_STUDIO_ARCH_AVX)
-CHECK_CXX_COMPILER_FLAG("/arch:AVX2" HAVE_VISUAL_STUDIO_ARCH_AVX2)
-CHECK_CXX_COMPILER_FLAG("-mavx" HAVE_CLANG_MAVX)
-CHECK_CXX_COMPILER_FLAG("-mbmi2" HAVE_CLANG_MBMI2)
-if(SNAPPY_REQUIRE_AVX2)
-  if(HAVE_VISUAL_STUDIO_ARCH_AVX2)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
-  endif(HAVE_VISUAL_STUDIO_ARCH_AVX2)
-  if(HAVE_CLANG_MAVX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
-  endif(HAVE_CLANG_MAVX)
-  if(HAVE_CLANG_MBMI2)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mbmi2")
-  endif(HAVE_CLANG_MBMI2)
-elseif (SNAPPY_REQUIRE_AVX)
-  if(HAVE_VISUAL_STUDIO_ARCH_AVX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX")
-  endif(HAVE_VISUAL_STUDIO_ARCH_AVX)
-  if(HAVE_CLANG_MAVX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
-  endif(HAVE_CLANG_MAVX)
-endif(SNAPPY_REQUIRE_AVX2)
-
 include(CheckCXXSourceCompiles)
+
+include(CheckSymbolExists)
+check_symbol_exists("mmap" "sys/mman.h" HAVE_FUNC_MMAP)
+check_symbol_exists("sysconf" "unistd.h" HAVE_FUNC_SYSCONF)
+
 check_cxx_source_compiles("
 int main() {
   return __builtin_expect(0, 1);
@@ -103,7 +85,33 @@ int main() {
   return __builtin_ctzll(0);
 }" HAVE_BUILTIN_CTZ)
 
-check_cxx_source_compiles("
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*|amd64.*|AMD64.*|x86_64.*")
+
+  CHECK_CXX_COMPILER_FLAG("/arch:AVX" HAVE_VISUAL_STUDIO_ARCH_AVX)
+  CHECK_CXX_COMPILER_FLAG("/arch:AVX2" HAVE_VISUAL_STUDIO_ARCH_AVX2)
+  CHECK_CXX_COMPILER_FLAG("-mavx" HAVE_CLANG_MAVX)
+  CHECK_CXX_COMPILER_FLAG("-mbmi2" HAVE_CLANG_MBMI2)
+  if(SNAPPY_REQUIRE_AVX2)
+    if(HAVE_VISUAL_STUDIO_ARCH_AVX2)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
+    endif(HAVE_VISUAL_STUDIO_ARCH_AVX2)
+    if(HAVE_CLANG_MAVX)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+    endif(HAVE_CLANG_MAVX)
+    if(HAVE_CLANG_MBMI2)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mbmi2")
+    endif(HAVE_CLANG_MBMI2)
+  elseif (SNAPPY_REQUIRE_AVX)
+    if(HAVE_VISUAL_STUDIO_ARCH_AVX)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX")
+    endif(HAVE_VISUAL_STUDIO_ARCH_AVX)
+    if(HAVE_CLANG_MAVX)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+    endif(HAVE_CLANG_MAVX)
+  endif(SNAPPY_REQUIRE_AVX2)
+
+  check_cxx_source_compiles("
 #include <tmmintrin.h>
 
 int main() {
@@ -115,15 +123,43 @@ int main() {
   return 0;
 }" SNAPPY_HAVE_SSSE3)
 
-check_cxx_source_compiles("
+  check_cxx_source_compiles("
 #include <immintrin.h>
 int main() {
   return _bzhi_u32(0, 1);
 }" SNAPPY_HAVE_BMI2)
 
-include(CheckSymbolExists)
-check_symbol_exists("mmap" "sys/mman.h" HAVE_FUNC_MMAP)
-check_symbol_exists("sysconf" "unistd.h" HAVE_FUNC_SYSCONF)
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "PPC64*|ppc64*|powerpc64*")
+
+# Ensure -mcpu=native , many distros still default to power8
+
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -mcpu=native")
+  check_cxx_source_compiles("
+#ifndef _ARCH_PWR9
+#error
+#endif
+int main() { return 0; }" SNAPPY_HAVE_PWR9)
+
+  check_cxx_source_compiles("
+#if !defined(__VSX__)
+#error 
+#endif
+int main() { return 0; }" SNAPPY_HAVE_VSX)
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
+
+  message("IBM ${CMAKE_SYSTEM_PROCESSOR} , have Power9: \"${SNAPPY_HAVE_PWR9}\" , have VSX: \"${SNAPPY_HAVE_VSX}\"")
+
+endif() # CMAKE_SYSTEM_PROCESSOR
+
+if (SNAPPY_C_ONLY)
+  set(SNAPPY_HAVE_SSSE3 OFF)
+  set(SNAPPY_HAVE_BMI2 OFF)
+  set(SNAPPY_HAVE_PWR9 OFF)
+  set(SNAPPY_HAVE_VSX OFF)
+  message("C Only Version, ${SNAPPY_HAVE_SSSE3} ${SNAPPY_HAVE_BMI2} ${SNAPPY_HAVE_PWR9} ${SNAPPY_HAVE_VSX}")
+endif()
+
 
 find_package(GTest QUIET)
 if(GTEST_FOUND)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -55,6 +55,13 @@
 /* Define to 1 if you target processors with BMI2+ and have <bmi2intrin.h>. */
 #cmakedefine01 SNAPPY_HAVE_BMI2
 
+/* Define to 1 if target processor is a Power9 (ISA 3.0). */
+#cmakedefine01 SNAPPY_HAVE_PWR9
+
+/* Define to 1 if target processor has VSX Extensions. */
+#cmakedefine01 SNAPPY_HAVE_VSX
+
+
 /* Define to 1 if your processor stores words with the most significant byte
    first (like Motorola and SPARC, unlike Intel and VAX). */
 #cmakedefine SNAPPY_IS_BIG_ENDIAN 1

--- a/snappy.cc
+++ b/snappy.cc
@@ -68,6 +68,33 @@
 #include <immintrin.h>
 #endif
 
+
+#if !defined(SNAPPY_HAVE_PWR9)
+#if defined(_ARCH_PWR9)
+#define SNAPPY_HAVE_PWR9 1
+#else
+#define SNAPPY_HAVE_PWR9 0
+#endif
+#endif
+
+#if !defined(SNAPPY_HAVE_VSX)
+#if defined(__VSX__)
+#define SNAPPY_HAVE_VSX 1
+#else
+#define SNAPPY_HAVE_VSX 0
+#endif
+#endif
+
+
+#if SNAPPY_HAVE_VSX
+#include <altivec.h>
+typedef uint8_t  v16u8 __attribute__((vector_size(16)));
+typedef uint32_t v8u16 __attribute__((vector_size(16)));
+typedef uint32_t v4u32 __attribute__((vector_size(16)));
+#endif
+
+
+
 #include <stdio.h>
 
 #include <algorithm>
@@ -252,6 +279,42 @@ inline char* IncrementalCopy(const char* src, char* op, char* const op_limit,
       if (SNAPPY_PREDICT_TRUE(op >= op_limit)) return op_limit;
     }
     return IncrementalCopySlow(src, op, op_limit);
+
+#elif SNAPPY_HAVE_PWR9
+
+      v16u8 vu8 = vec_xl_len((uint8_t*)src, pattern_size);
+
+      uint32_t np = 16 / pattern_size , ns = pattern_size * np;
+      for (int ix=1; ix<np; ix++)
+          vec_xst_len(vu8, (uint8_t*)&vu8+(ix*pattern_size), pattern_size);
+
+      char* op_end = std::min(op_limit, buf_limit - 15);
+      while (uint64_t(op_limit-op) >= ns) {
+          vec_xst_len(vu8, (uint8_t*)op, ns);
+          op += ns;
+      }
+      if (SNAPPY_PREDICT_TRUE(op >= op_limit)) return op_limit;
+      return IncrementalCopySlow(src, op, op_limit);
+
+#elif SNAPPY_HAVE_VSX
+
+      if (SNAPPY_PREDICT_TRUE(op <= buf_limit - 16))
+      {
+          v16u8 vu8 = vec_vsx_ld(0, (uint8_t*)src);
+
+          uint32_t np = 16 / pattern_size , ns = pattern_size * np;	
+          for(uint32_t ix=0; ix<np; ix++)
+              memcpy((uint8_t*)&vu8+(ix*pattern_size), src, pattern_size);	// vu|=vu<<pattern_size
+
+          char* op_end = std::min(op_limit, buf_limit - 15);
+          while (op < op_end) {
+              vec_vsx_st(vu8, 0, (uint8_t*)op);
+              op += ns;
+          }
+          if (SNAPPY_PREDICT_TRUE(op >= op_limit)) return op_limit;
+      }
+      return IncrementalCopySlow(src, op, op_limit);
+
 #else  // !SNAPPY_HAVE_SSSE3
     // If plenty of buffer space remains, expand the pattern to at least 8
     // bytes. The way the following loop is written, we need 8 bytes of buffer
@@ -721,8 +784,8 @@ static inline uint32 ExtractLowBytes(uint32 v, int n) {
   return _bzhi_u32(v, 8 * n);
 #else
   // This needs to be wider than uint32 otherwise `mask << 32` will be
-  // undefined.
-  uint64 mask = 0xffffffff;
+  // undefined. 
+  uint64 mask = ~0;
   return v & ~(mask << (8 * n));
 #endif
 }


### PR DESCRIPTION
"Minimal changes to add reasonable support for POWER architecture detection,  for use in IncrementalCopy().  Power9 has true unaligned loads and stores, Power8 uses the equivalent of the SSE2 code."

I hope you will consider pulling,  the performance for this is roughly similar to the gain from the SSE2 code for Power8 and a bit higher for Power9.

I may have other optimizations as well, If you are interested in support for this architecture.
