### PR TITLE
update snappy.cc Optimize by about 7.82%

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -91,10 +91,7 @@ using internal::LITERAL;
 // compression for compressible input, and more speed for incompressible
 // input. Of course, it doesn't hurt if the hash function is reasonably fast
 // either, as it gets called a lot.
-static inline uint32_t HashBytes(uint32_t bytes, int shift) {
-  uint32_t kMul = 0x1e35a7bd;
-  return (bytes * kMul) >> shift;
-}
+#define HashBytes(bytes, shift) ((uint32)((bytes) * (0x1e35a7bd)) >> (shift))
 
 size_t MaxCompressedLength(size_t source_bytes) {
   // Compressed data can be defined as:


### PR DESCRIPTION
Replacing functions with macros to improve performance. snappy_unittest Optimize by about 7.82%.
name	old speed	new speed	improve
BM_UFlat/0	324.8	319.8	-1.54%
BM_UFlat/1	291.6	289.5	-0.72%
BM_UFlat/2	17.4	17.5	0.57%
BM_UFlat/3	290.4	299.3	3.06%
BM_UFlat/4	2.6	2.6	0.00%
BM_UFlat/5	416.5	410.3	-1.49%
BM_UFlat/6	125.7	159.4	26.81%
BM_UFlat/7	153.8	151.7	-1.37%
BM_UFlat/8	173.1	170.6	-1.44%
BM_UFlat/9	143.1	141.4	-1.19%
BM_UFlat/10	406.3	523.1	28.75%
BM_UFlat/11	188.6	184.7	-2.07%
BM_UIOVec/0	293.3	305.9	4.30%
BM_UIOVec/1	226.6	232.6	2.65%
BM_UIOVec/2	20.5	20.8	1.46%
BM_UIOVec/3	204.5	204	-0.24%
BM_UIOVec/4	2.7	2.9	7.41%
BM_UValidate/0	873	874.1	0.13%
BM_UValidate/1	537.1	536.1	-0.19%
BM_UValidate/2	231.2	229.1	-0.91%
BM_UValidate/3	592.7	577.2	-2.62%
BM_UValidate/4	9	9	0.00%
BM_ZFlat/0	161.9	181.2	11.92%
BM_ZFlat/1	85.5	100.7	17.78%
BM_ZFlat/2	5.6	7.2	28.57%
BM_ZFlat/3	71.4	95.1	33.19%
BM_ZFlat/4	1.5	1.7	13.33%
BM_ZFlat/5	159.8	179.2	12.14%
BM_ZFlat/6	61.1	68.3	11.78%
BM_ZFlat/7	58.1	65.2	12.22%
BM_ZFlat/8	64.6	72.2	11.76%
BM_ZFlat/9	54.8	61.5	12.23%
BM_ZFlat/10	203.3	230.1	13.18%
BM_ZFlat/11	90.2	97.7	8.31%
BM_ZFlatAll/0	85.5	96.7	13.10%
BM_ZFlatIncreasingTableSize/0	94.9	114.5	20.65%

AVG :			7.82%