### PR TITLE
fix compile warnings due to missing override specifiers

### DIFF
--- a/snappy-sinksource.h
+++ b/snappy-sinksource.h
@@ -147,9 +147,9 @@ class ByteArraySource : public Source {
  public:
   ByteArraySource(const char* p, size_t n) : ptr_(p), left_(n) { }
   virtual ~ByteArraySource();
-  virtual size_t Available() const;
-  virtual const char* Peek(size_t* len);
-  virtual void Skip(size_t n);
+  virtual size_t Available() const override;
+  virtual const char* Peek(size_t* len) override;
+  virtual void Skip(size_t n) override;
  private:
   const char* ptr_;
   size_t left_;
@@ -160,14 +160,14 @@ class UncheckedByteArraySink : public Sink {
  public:
   explicit UncheckedByteArraySink(char* dest) : dest_(dest) { }
   virtual ~UncheckedByteArraySink();
-  virtual void Append(const char* data, size_t n);
-  virtual char* GetAppendBuffer(size_t len, char* scratch);
+  virtual void Append(const char* data, size_t n) override;
+  virtual char* GetAppendBuffer(size_t len, char* scratch) override;
   virtual char* GetAppendBufferVariable(
       size_t min_size, size_t desired_size_hint, char* scratch,
-      size_t scratch_size, size_t* allocated_size);
+      size_t scratch_size, size_t* allocated_size) override;
   virtual void AppendAndTakeOwnership(
       char* bytes, size_t n, void (*deleter)(void*, const char*, size_t),
-      void *deleter_arg);
+      void *deleter_arg) override;
 
   // Return the current output pointer so that a caller can see how
   // many bytes were produced.


### PR DESCRIPTION
When building Snappy with compiler option `-Wsuggest-override` set
via the CMAKE_CXX_FLAGS, compilation produces warnings in
`snappy-sinksource.h`:

```
In file included from ./snappy-fork/snappy-sinksource.cc:32:
./snappy-fork/snappy-sinksource.h:150:18: error: ‘virtual size_t snappy::ByteArraySource::Available() const’ can be marked override [-Werror=suggest-override]
  150 |   virtual size_t Available() const;
      |                  ^~~~~~~~~
./snappy-fork/snappy-sinksource.h:151:23: error: ‘virtual const char* snappy::ByteArraySource::Peek(size_t*)’ can be marked override [-Werror=suggest-override]
  151 |   virtual const char* Peek(size_t* len);
      |                       ^~~~
./snappy-fork/snappy-sinksource.h:152:16: error: ‘virtual void snappy::ByteArraySource::Skip(size_t)’ can be marked override [-Werror=suggest-override]
  152 |   virtual void Skip(size_t n);
      |                ^~~~
./snappy-fork/snappy-sinksource.h:163:16: error: ‘virtual void snappy::UncheckedByteArraySink::Append(const char*, size_t)’ can be marked override [-Werror=suggest-override]
  163 |   virtual void Append(const char* data, size_t n);
      |                ^~~~~~
./snappy-fork/snappy-sinksource.h:164:17: error: ‘virtual char* snappy::UncheckedByteArraySink::GetAppendBuffer(size_t, char*)’ can be marked override [-Werror=suggest-override]
  164 |   virtual char* GetAppendBuffer(size_t len, char* scratch);
      |                 ^~~~~~~~~~~~~~~
./snappy-fork/snappy-sinksource.h:165:17: error: ‘virtual char* snappy::UncheckedByteArraySink::GetAppendBufferVariable(size_t, size_t, char*, size_t, size_t*)’ can be marked override [-Werror=suggest-override]
  165 |   virtual char* GetAppendBufferVariable(
      |                 ^~~~~~~~~~~~~~~~~~~~~~~
./snappy-fork/snappy-sinksource.h:168:16: error: ‘virtual void snappy::UncheckedByteArraySink::AppendAndTakeOwnership(char*, size_t, void (*)(void*, const char*, size_t), void*)’ can be marked override [-Werror=suggest-override]
  168 |   virtual void AppendAndTakeOwnership(
      |                ^~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

This PR adds the missing override specifiers to the sink
implementations, so compilation works fine again.

Tested it with g++-9.3 and g++-10.2.

Compatibility note:
Override specifiers were introduced with C++11, which Snappy seems
to effectively require, at least according to its CMakeLists.txt file
and due to the usage of some C++11-only STL types in its tests.