### PR TITLE
Fix compilation in clang, unused variable

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -93,7 +93,7 @@ using internal::LITERAL;
 // The returned format encodes the offset in the high byte and the length
 // in the low byte. Because length will never be 0, we use zero as an indicator
 // for an exceptional value (copy 3 tag or a literal > 60 bytes).
-constexpr size_t kLiteralOffset = 256;
+//constexpr size_t kLiteralOffset = 256;
 inline constexpr uint16_t MakeEntry(uint16_t len, uint16_t offset) {
   return len | (offset << 8);
 }


### PR DESCRIPTION
Compilign with clang in OSX gives this:

    snappy.cc:96:18: error: unused variable 'kLiteralOffset' [-Werror,-Wunused-const-variable]

A recent commit replaced the uses of kLiteralOffset,  but it is
still mentioned in comments, so to keep those making some sense,
this commit comments out the variable too.