### PR TITLE
Added -Wno-ignored-attribute for clang/gcc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,11 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
   endif(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
 
+  # -Wno-ignored-attributes for clang and gcc.
+  if(NOT CMAKE_CXX_FLAGS MATCHES "-Wno-ignored-attributes")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-attributes")
+  endif(NOT CMAKE_CXX_FLAGS MATCHES "-Wno-ignored-attributes")
+
   # Disable C++ exceptions.
   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")


### PR DESCRIPTION
Compiler warning when unable to inline a template./