### PR TITLE
Building with `-Werror` only with clang.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,7 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   endif(NOT CMAKE_CXX_FLAGS MATCHES "-Wextra")
 
   # Use -Werror for clang only.
-  # There are many clang compiler ID's, but only one gcc.
-  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GCC")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
     endif(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,13 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
   endif(NOT CMAKE_CXX_FLAGS MATCHES "-Wextra")
 
-  # Use -Werror for clang and gcc.
-  if(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-  endif(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
+  # Use -Werror for clang only.
+  # There are many clang compiler ID's, but only one gcc.
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GCC")
+    if(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    endif(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
+  endif(CMAKE_CXX_COMPILER_ID STREQUAL "GCC")
 
   # Disable C++ exceptions.
   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     if(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
     endif(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
-  endif(CMAKE_CXX_COMPILER_ID STREQUAL "GCC")
+  endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
   # Disable C++ exceptions.
   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
gcc was unable to inline a function call, which caused a build
failure due to `-Wall -Werror`.

The build error was:

```
../snappy.cc:292:76: error: ignoring attributes on template argument ‘__m128i’ [-Werror=ignored-attributes]
  292 | static inline std::pair<__m128i /* pattern */, __m128i /* reshuffle_mask */>
      |                                                                            ^
../snappy.cc:292:76: error: ignoring attributes on template argument ‘__m128i’ [-Werror=ignored-attributes]
cc1plus: all warnings being treated as errors
```