### PR TITLE
Disable fuzzing on OSX.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ install:
     export PATH="$(brew --prefix llvm)/bin:$PATH";
   fi
 # Fuzzing is only supported on Clang. Perform fuzzing on Debug builds.
-- if [ "$CXX" = "clang++" ] && [ "$BUILD_TYPE" = "Debug" ]; then
+# LibFuzzer doesn't ship with CommandLineTools on osx.
+- if [ "$CXX" = "clang++" ] && [ "$BUILD_TYPE" = "Debug" ] && [ "$TRAVIS_OS_NAME" != "osx" ]; then
     export FUZZING=1;
   else
     export FUZZING=0;


### PR DESCRIPTION
LibFuzzer does not ship with the Mac OSX Command Line Tools.

```
ld: file not found: /Applications/Xcode-12.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/12.0.0/lib/darwin/libclang_rt.fuzzer_osx.a

clang: error: linker command failed with exit code 1 (use -v to see invocation)
```