### PR TITLE
Add inline with SNAPPY_ATTRIBUTE_ALWAYS_INLINE

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1014,7 +1014,7 @@ void MemMove(ptrdiff_t dst, const void* src, size_t size) {
 }
 
 SNAPPY_ATTRIBUTE_ALWAYS_INLINE
-size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
+inline size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
   const uint8_t*& ip = *ip_p;
   // This section is crucial for the throughput of the decompression loop.
   // The latency of an iteration is fundamentally constrained by the


### PR DESCRIPTION
Add `inline` with `SNAPPY_ATTRIBUTE_ALWAYS_INLINE` on `AdvanceToNextTag` to fix the following compilation errors and a warning with GCC:

```
[  2%] Building CXX object CMakeFiles/snappy.dir/snappy.cc.o
/usr/bin/c++   -DHAVE_CONFIG_H -Dsnappy_EXPORTS -I/usr/src/tmp/snappy-1.1.9/build -I/usr/src/tmp/snappy-1.1.9  -O3 -march=i586 -mtune=i686 -Wall -Wextra -fno-exceptions -fno-rtti -O3 -DNDEBUG -fPIC   -std=c++11 -o CMakeFiles/snappy.dir/snappy.cc.o -c /usr/src/tmp/snappy-1.1.9/snappy.cc
/usr/src/tmp/snappy-1.1.9/snappy.cc:1017:8: warning: always_inline function might not be inlinable [-Wattributes]
 size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
        ^
/usr/src/tmp/snappy-1.1.9/snappy.cc: In function 'std::pair<const unsigned char*, int> snappy::DecompressBranchless(const uint8_t*, const uint8_t*, ptrdiff_t, T, ptrdiff_t) [with T = char*; uint8_t = unsigned char; ptrdiff_t = int]':
/usr/src/tmp/snappy-1.1.9/snappy.cc:1017:8: error: inlining failed in call to always_inline 'size_t snappy::AdvanceToNextTag(const uint8_t**, size_t*)': function body can be overwritten at link time
/usr/src/tmp/snappy-1.1.9/snappy.cc:1097:53: error: called from here
         size_t tag_type = AdvanceToNextTag(&ip, &tag);
                                                     ^
/usr/src/tmp/snappy-1.1.9/snappy.cc:1017:8: error: inlining failed in call to always_inline 'size_t snappy::AdvanceToNextTag(const uint8_t**, size_t*)': function body can be overwritten at link time
 size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
        ^
/usr/src/tmp/snappy-1.1.9/snappy.cc:1097:53: error: called from here
         size_t tag_type = AdvanceToNextTag(&ip, &tag);
                                                     ^
/usr/src/tmp/snappy-1.1.9/snappy.cc:1017:8: error: inlining failed in call to always_inline 'size_t snappy::AdvanceToNextTag(const uint8_t**, size_t*)': function body can be overwritten at link time
 size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
        ^
/usr/src/tmp/snappy-1.1.9/snappy.cc:1097:53: error: called from here
         size_t tag_type = AdvanceToNextTag(&ip, &tag);
                                                     ^
CMakeFiles/snappy.dir/build.make:137: recipe for target 'CMakeFiles/snappy.dir/snappy.cc.o' failed
```

Just like with other functions using `SNAPPY_ATTRIBUTE_ALWAYS_INLINE` macro (i.e. `__attribute__((always_inline))` ) it is necessary to use C++ `inline` specifier.