### PR TITLE
Use local variable to hold masks table

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1069,7 +1069,8 @@ size_t AdvanceToNextTagX86Optimized(const uint8_t** ip_p, size_t* tag) {
 
 // Extract the offset for copy-1 and copy-2 returns 0 for literals or copy-4.
 inline uint32_t ExtractOffset(uint32_t val, size_t tag_type) {
-  return val & table.extract_masks[tag_type];
+  static const uint32_t extract_masks[4] = {0, 0xFF, 0xFFFF, 0};
+  return val & extract_masks[tag_type];
 };
 
 // Core decompression loop, when there is enough data available.


### PR DESCRIPTION
This will remove one instruction to calc mask table
addr. See https://www.godbolt.org/z/YMG71nEe6
~1.5% decompression performance uplift is observed on N1.

Signed-off-by: Jun He <jun.he@arm.com>
Change-Id: I79be1dbdc336c8a3a5776a0092fc3d4b8deaae18