### PR TITLE
Enable rtti for snappy build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,6 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Disable C++ exceptions.
   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
-
-  # Disable RTTI.
-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
 # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make


### PR DESCRIPTION
Without rtti build fails to link when implementing a custom
snappy::Source/Sink.

https://github.com/facebook/folly/issues/1606

Signed-off-by: Noah Watkins <noah@vectorized.io>