### PR TITLE
Re-enable RTTI (needed in order to subclass Source, etc.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   string(REGEX REPLACE "/EH[a-z]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c-")
   add_definitions(-D_HAS_EXCEPTIONS=0)
-
-  # Disable RTTI.
-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Use -Wall for clang and gcc.
   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
@@ -77,9 +73,6 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 
-  # Disable RTTI.
-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
 # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make


### PR DESCRIPTION
Commit c98344f in snappy 1.1.9 disabled RTTI, which means the snappy library no longer exports typeinfo for snappy::Source, snappy::Sink, ..., so users of the library can't subclass these classes anymore.

Here's a trivial reproducer:

```
  #include <snappy-sinksource.h>
  class MySource : snappy::Source {
  public:
    size_t Available() const override { return 0; }
    const char *Peek(size_t *len) override { return NULL; }
    void Skip(size_t n) override {}
  };
  int main(int argc, char **argv) {
    MySource m;
    return 0;
  }
```

Try `g++ -o snappy-test ./snappy-test.cc -lsnappy` with the above and the linker will fail with "undefined reference to `typeinfo for snappy::Source'" if RTTI was disabled in the snappy build.