### PR TITLE
Replace biconditional logical connective 'iff' with 'if'.

### DIFF
--- a/snappy-sinksource.h
+++ b/snappy-sinksource.h
@@ -117,7 +117,7 @@ class Source {
   virtual size_t Available() const = 0;
 
   // Peek at the next flat region of the source.  Does not reposition
-  // the source.  The returned region is empty iff Available()==0.
+  // the source.  The returned region is empty if Available()==0.
   //
   // Returns a pointer to the beginning of the region and store its
   // length in *len.

--- a/snappy-stubs-internal.h
+++ b/snappy-stubs-internal.h
@@ -249,7 +249,7 @@ class Bits {
   // Return floor(log2(n)) for positive integer n.
   static int Log2FloorNonZero(uint32_t n);
 
-  // Return floor(log2(n)) for positive integer n.  Returns -1 iff n == 0.
+  // Return floor(log2(n)) for positive integer n.  Returns -1 if n == 0.
   static int Log2Floor(uint32_t n);
 
   // Return the first set least / most significant bit, 0-indexed.  Returns an

--- a/snappy-test.cc
+++ b/snappy-test.cc
@@ -458,7 +458,7 @@ int ZLib::UncompressAtMost(Bytef *dest, uLongf *destLen,
 // We make sure we've uncompressed everything, that is, the current
 // uncompress stream is at a compressed-buffer-EOF boundary.  In gzip
 // mode, we also check the gzip footer to make sure we pass the gzip
-// consistency checks.  We RETURN true iff both types of checks pass.
+// consistency checks.  We RETURN true if both types of checks pass.
 bool ZLib::UncompressChunkDone() {
   assert(!first_chunk_ && uncomp_init_);
   // Make sure we're at the end-of-compressed-data point.  This means

--- a/snappy-test.h
+++ b/snappy-test.h
@@ -283,7 +283,7 @@ class ZLib {
   // Checks gzip footer information, as needed.  Mostly this just
   // makes sure the checksums match.  Whenever you call this, it
   // will assume the last 8 bytes from the previous UncompressChunk
-  // call are the footer.  Returns true iff everything looks ok.
+  // call are the footer.  Returns true if everything looks ok.
   bool UncompressChunkDone();
 
  private:

--- a/snappy.cc
+++ b/snappy.cc
@@ -1224,7 +1224,7 @@ class SnappyDecompressor {
     reader_->Skip(peeked_);
   }
 
-  // Returns true iff we have hit the end of the input without an error.
+  // Returns true if we have hit the end of the input without an error.
   bool eof() const { return eof_; }
 
   // Read the uncompressed length stored at the start of the compressed data.

--- a/snappy.h
+++ b/snappy.h
@@ -172,14 +172,14 @@ namespace snappy {
   bool GetUncompressedLength(const char* compressed, size_t compressed_length,
                              size_t* result);
 
-  // Returns true iff the contents of "compressed[]" can be uncompressed
+  // Returns true if the contents of "compressed" can be uncompressed
   // successfully.  Does not return the uncompressed data.  Takes
   // time proportional to compressed_length, but is usually at least
   // a factor of four faster than actual decompression.
   bool IsValidCompressedBuffer(const char* compressed,
                                size_t compressed_length);
 
-  // Returns true iff the contents of "compressed" can be uncompressed
+  // Returns true if the contents of "compressed" can be uncompressed
   // successfully.  Does not return the uncompressed data.  Takes
   // time proportional to *compressed length, but is usually at least
   // a factor of four faster than actual decompression.


### PR DESCRIPTION
Hello.

If that was not the typos at the comment sections I assume that was using of [biconditional logical connective](https://en.wikipedia.org/wiki/If_and_only_if) that probably not necessary in that cases.

Proposed to replace it with 'if'.

Thank you.

P.S.
There is a place in third-party section but that is a git sub-module so not changed it via this request.