### PR TITLE
Add branch hint to a low probability path

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -697,13 +697,13 @@ static inline char* EmitCopy(char* op, size_t offset, size_t len) {
     }
 
     // One or two copies will now finish the job.
-    if (len > 64) {
+    if (SNAPPY_PREDICT_FALSE(len > 64)) {
       op = EmitCopyAtMost64</*len_less_than_12=*/false>(op, offset, 60);
       len -= 60;
     }
 
     // Emit remainder.
-    if (len < 12) {
+    if (SNAPPY_PREDICT_FALSE(len < 12)) {
       op = EmitCopyAtMost64</*len_less_than_12=*/true>(op, offset, len);
     } else {
       op = EmitCopyAtMost64</*len_less_than_12=*/false>(op, offset, len);


### PR DESCRIPTION
Profiling shows that (len>64) and following (len<12) are in low probability path:3% and 6%. Adding hint could help on better pipeline friendly code.
Observed ~2% in geo.protodata, and ~1% in html*,urls.

Signed-off-by: Jun He <jun.he@arm.com>
Change-Id: Iababb7df62e4e587afb3bfd93f4e40bef96684dd