### PR TITLE
Add explicit static_cast to remove compiler error

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1290,7 +1290,7 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
         DeferMemCopy(&deferred_src, &deferred_length, from, len);
       }
     } while (ip < ip_limit_min_slop &&
-             (op + deferred_length) < op_limit_min_slop);
+             (op + static_cast<ptrdiff_t>(deferred_length)) < op_limit_min_slop);
   exit:
     ip--;
     assert(ip <= ip_limit);


### PR DESCRIPTION
This error occurs when building with the `Clang` compiler.

Another error is located in the `benchmark` submodule:

```
programming/snappy/third_party/benchmark/src/complexity.cc:85:10: error: variable 'sigma_gn' set but not used [-Werror,-Wunused-but-set-variable]
  double sigma_gn = 0.0;
```

However, this is fixed in its `main` branch.
BTW, snappy's submodules haven't been updating for years.

I was able to fix that with `git submodule update --remote`, but I didn't include those changes in this PR because I'm not aware of all the possible repercussions of such changes.
