### PR TITLE
Specifically check for NEON for ARMv8 CPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,9 +207,9 @@ int main() {
 check_cxx_source_compiles("
 #include <arm_neon.h>
 int main() {
-  uint8_t val = 3, dup[8];
+  uint8_t val = 3;
   uint8x16_t v = vld1q_dup_u8(&val);
-  vst1q_u8(dup, v);
+  val = vmaxvq_u8(v);
   return 0;
 }" SNAPPY_HAVE_NEON)
 


### PR DESCRIPTION
The actual NEON implementation uses instructions that are not supported on 32-bit CPUs.  These errors happen when building for armv7a:

```
/var/tmp/portage/app-arch/snappy-1.1.10-r1/work/snappy-1.1.10/snappy-internal.h:106:10: error: ‘vminvq_u8’ was not declared in this scope; did you mean ‘vminq_u8’?
  106 |   assert(vminvq_u8(shuffle_mask) >= 0 && vmaxvq_u8(shuffle_mask) <= 15);
      |          ^~~~~~~~~
/var/tmp/portage/app-arch/snappy-1.1.10-r1/work/snappy-1.1.10/snappy-internal.h:106:42: error: ‘vmaxvq_u8’ was not declared in this scope; did you mean ‘vmaxq_u8’?
  106 |   assert(vminvq_u8(shuffle_mask) >= 0 && vmaxvq_u8(shuffle_mask) <= 15);
      |                                          ^~~~~~~~~
/var/tmp/portage/app-arch/snappy-1.1.10-r1/work/snappy-1.1.10/snappy-internal.h:107:10: error: ‘vqtbl1q_u8’ was not declared in this scope; did you mean ‘vtbl1_u8’?
  107 |   return vqtbl1q_u8(input, shuffle_mask);
      |          ^~~~~~~~~~
      |          vtbl1_u8
```

This PR just makes the CMake test use the `vmaxvq_u8` intrinsic to find the maximum vector element to test for A64 NEON, since that's an instruction used in the code.  You can check supported instruction targets here: https://arm-software.github.io/acle/neon_intrinsics/advsimd.html