### PR TITLE
Add a new option for requiring BMI2 intrinsics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,8 @@ option(SNAPPY_REQUIRE_AVX "Target processors with AVX support." OFF)
 
 option(SNAPPY_REQUIRE_AVX2 "Target processors with AVX2 support." OFF)
 
+option(SNAPPY_REQUIRE_BMI2 "Target processors with BMI2 support." ON)
+
 option(SNAPPY_INSTALL "Install Snappy's header and library" ON)
 
 include(TestBigEndian)
@@ -185,11 +187,15 @@ int main() {
   return __crc32cw(0, 1);
 }" SNAPPY_HAVE_NEON_CRC32)
 
-check_cxx_source_compiles("
-#include <immintrin.h>
-int main() {
-  return _bzhi_u32(0, 1);
-}" SNAPPY_HAVE_BMI2)
+if(SNAPPY_REQUIRE_BMI2)
+  check_cxx_source_compiles("
+  #include <immintrin.h>
+  int main() {
+    return _bzhi_u32(0, 1);
+  }" SNAPPY_HAVE_BMI2)
+else()
+  set(SNAPPY_HAVE_BMI2 FALSE)
+endif(SNAPPY_REQUIRE_BMI2)
 
 check_cxx_source_compiles("
 #include <arm_neon.h>


### PR DESCRIPTION
If in an envioronment where the desired output code will be run on a broad set of x86 CPUs, BMI2 isn't guaranteed to be available. When compiling against MSVC, `bzhi` will still be inserted into the instruction stream because the `SNAPPY_HAVE_BMI2` check will succeeed (MSVC compiles without issue), but cannot be run by Sandy Bridge and earlier CPU generations.