### PR TITLE
Add missing <functional> include

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -74,6 +74,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
`std::less` is defined in `<functional>` which is missing from snappy.cc and causes compilation issues with older compilers e.g. [XCode 10 AppleClang](https://github.com/ursacomputing/crossbow/actions/runs/6256645944/job/16987817696#step:5:569). 