### PR TITLE
Fixup building with AVX flag

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -60,7 +60,7 @@
 #endif
 #endif  // !defined(SNAPPY_HAVE_NEON_CRC32)
 
-#if SNAPPY_HAVE_BMI2 || SNAPPY_HAVE_X86_CRC32
+#if SNAPPY_HAVE_BMI2 || SNAPPY_HAVE_X86_CRC32 || ((defined(__x86_64__) && defined(__AVX__))
 // Please do not replace with <x86intrin.h>. or with headers that assume more
 // advanced SSE versions without checking with all the OWNERS.
 #include <immintrin.h>


### PR DESCRIPTION
At this [point](https://github.com/google/snappy/blob/27f34a580be4a3becf5f8c0cba13433f53c21337/snappy.cc#L1054) avx instructions uses under `__AVX__` flag. But header `<immintrin.h>` needed to working with this instructions [includes](https://github.com/google/snappy/blob/27f34a580be4a3becf5f8c0cba13433f53c21337/snappy.cc#L66) only if `__BMI2__`, `__SSE4_2__` or `__AVX2__` flags enabled. So building with only AVX instructions is broken now.

Trying to fix it.