### PR TITLE
Perf tuning for gcc + aarch64

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -100,6 +100,57 @@ using internal::V128_StoreU;
 using internal::V128_DupChar;
 #endif
 
+// GCC dispatches to libc for memmoves > 16 bytes, so we need to
+// do some work to get good code from that compiler. Clang handles
+// powers-of-2 at least up to 64 well.
+#if !defined(__GNUC__) || defined(__clang__)
+template <size_t SIZE>
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline void FixedSizeMemMove(void* dest, const void* src) {
+  memmove(dest, src, SIZE);
+}
+#else
+
+template <size_t SIZE>
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline void FixedSizeMemMove(void* dest, const void* src) {
+  if (SIZE <= 16) {
+    // gcc has patterns for memmove up to 16 bytes
+    memmove(dest, src, SIZE);
+  } else {
+    // This generates reasonable code on x86_64, but on aarch64 this produces a
+    // dead store to tmp, plus takes up stack space.
+    char tmp[SIZE];
+    memcpy(tmp, src, SIZE);
+    memcpy(dest, tmp, SIZE);
+  }
+}
+
+#ifdef __aarch64__ // Implies neon support
+template <>
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline void FixedSizeMemMove<32>(void* dest, const void* src) {
+  V128 a = V128_LoadU(reinterpret_cast<const V128*>(src));
+  V128 b = V128_LoadU(reinterpret_cast<const V128*>(src) + 1);
+  V128_StoreU(reinterpret_cast<V128*>(dest), a);
+  V128_StoreU(reinterpret_cast<V128*>(dest) + 1, b);
+}
+
+template <>
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline void FixedSizeMemMove<64>(void* dest, const void* src) {
+  V128 a = V128_LoadU(reinterpret_cast<const V128*>(src));
+  V128 b = V128_LoadU(reinterpret_cast<const V128*>(src) + 1);
+  V128 c = V128_LoadU(reinterpret_cast<const V128*>(src) + 2);
+  V128 d = V128_LoadU(reinterpret_cast<const V128*>(src) + 3);
+  V128_StoreU(reinterpret_cast<V128*>(dest), a);
+  V128_StoreU(reinterpret_cast<V128*>(dest) + 1, b);
+  V128_StoreU(reinterpret_cast<V128*>(dest) + 2, c);
+  V128_StoreU(reinterpret_cast<V128*>(dest) + 3, d);
+}
+#endif
+#endif
+
 // We translate the information encoded in a tag through a lookup table to a
 // format that requires fewer instructions to decode. Effectively we store
 // the length minus the tag part of the offset. The lowest significant byte
@@ -1060,13 +1111,18 @@ void MemCopy64(char* dst, const void* src, size_t size) {
     data = _mm256_lddqu_si256(static_cast<const __m256i *>(src) + 1);
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst) + 1, data);
   }
+#elif defined(__aarch64__)
+  // Emperically it is faster to just copy all 64 rather than branching.
+  (void)kShortMemCopy;
+  (void)size;
+  FixedSizeMemMove<64>(dst, src);
 #else
-  std::memmove(dst, src, kShortMemCopy);
+  FixedSizeMemMove<kShortMemCopy>(dst, src);
   // Profiling shows that nearly all copies are short.
   if (SNAPPY_PREDICT_FALSE(size > kShortMemCopy)) {
-    std::memmove(dst + kShortMemCopy,
-                 static_cast<const uint8_t*>(src) + kShortMemCopy,
-                 64 - kShortMemCopy);
+    FixedSizeMemMove<kShortMemCopy>(
+        dst + kShortMemCopy,
+        static_cast<const uint8_t*>(src) + kShortMemCopy);
   }
 #endif
 }
@@ -1102,14 +1158,9 @@ inline size_t AdvanceToNextTagARMOptimized(const uint8_t** ip_p, size_t* tag) {
   // instruction (csinc) and it removes several register moves.
   const size_t tag_type = *tag & 3;
   const bool is_literal = (tag_type == 0);
-  if (is_literal) {
-    size_t next_literal_tag = (*tag >> 2) + 1;
-    *tag = ip[next_literal_tag];
-    ip += next_literal_tag + 1;
-  } else {
-    *tag = ip[tag_type];
-    ip += tag_type + 1;
-  }
+  const size_t next_tag = is_literal ? (*tag >> 2) + 1 : tag_type;
+  *tag = ip[next_tag];
+  ip += (next_tag) + 1;
   return tag_type;
 }
 
@@ -2013,7 +2064,7 @@ class SnappyArrayWriter {
       *op_p = IncrementalCopy(op - offset, op, op_end, op_limit_);
       return true;
     }
-    std::memmove(op, op - offset, kSlopBytes);
+    FixedSizeMemMove<kSlopBytes>(op, op - offset);
     *op_p = op_end;
     return true;
   }
@@ -2265,7 +2316,7 @@ class SnappyScatteredWriter {
     }
     // Fast path
     char* const op_end = op + len;
-    std::memmove(op, op - offset, kSlopBytes);
+    FixedSizeMemMove<kSlopBytes>(op, op - offset);
     *op_p = op_end;
     return true;
   }


### PR DESCRIPTION
The current codebase appears to have been tuned under clang, and there are a handful of patterns that gcc doesn't recognize that are critical to perf.  Benchmarks were run on a graviton2/neoverse-n1 core with gcc-11.2.

New Perf:
```
2024-01-18T15:16:45+00:00
Running build/snappy_benchmark
Run on (16 X 243.75 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x16)
  L1 Instruction 64 KiB (x16)
  L2 Unified 1024 KiB (x16)
  L3 Unified 32768 KiB (x1)
Load Average: 0.14, 0.45, 0.44
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
BM_UFlat/0                       30579 ns        30578 ns        22886 bytes_per_second=3.11878G/s html
BM_UFlat/1                      332963 ns       332964 ns         2102 bytes_per_second=1.96378G/s urls
BM_UFlat/2                        3957 ns         3957 ns       176929 bytes_per_second=28.9678G/s jpg
BM_UFlat/3                         158 ns          158 ns      4420971 bytes_per_second=1.17675G/s jpg_200
BM_UFlat/4                        5864 ns         5864 ns       119168 bytes_per_second=16.2639G/s pdf
BM_UFlat/5                      123479 ns       123474 ns         5669 bytes_per_second=3.08947G/s html4
BM_UFlat/6                      131128 ns       131126 ns         5337 bytes_per_second=1106.14M/s txt1
BM_UFlat/7                      115026 ns       115024 ns         6085 bytes_per_second=1037.87M/s txt2
BM_UFlat/8                      344359 ns       344347 ns         2033 bytes_per_second=1.1542G/s txt3
BM_UFlat/9                      475850 ns       475842 ns         1471 bytes_per_second=965.738M/s txt4
BM_UFlat/10                      26289 ns        26289 ns        26632 bytes_per_second=4.20121G/s pb
BM_UFlat/11                     140067 ns       140067 ns         4995 bytes_per_second=1.22556G/s gaviota
BM_UFlatMedley                 1738983 ns      1738950 ns          403 bytes_per_second=1.56844G/s
BM_UValidate/0                   24227 ns        24227 ns        28890 bytes_per_second=3.93646G/s html
BM_UValidate/1                  268613 ns       268608 ns         2606 bytes_per_second=2.43429G/s urls
BM_UValidate/2                     145 ns          145 ns      4721927 bytes_per_second=790.638G/s jpg
BM_UValidate/3                    98.2 ns         98.2 ns      7089287 bytes_per_second=1.89654G/s jpg_200
BM_UValidate/4                    2411 ns         2411 ns       290391 bytes_per_second=39.5581G/s pdf
BM_UValidate/5                   98246 ns        98244 ns         7125 bytes_per_second=3.88288G/s html4
BM_UValidate/6                  107937 ns       107935 ns         6485 bytes_per_second=1.31231G/s txt1
BM_UValidate/7                   94753 ns        94751 ns         7386 bytes_per_second=1.23041G/s txt2
BM_UValidate/8                  284073 ns       284061 ns         2464 bytes_per_second=1.39916G/s txt3
BM_UValidate/9                  393234 ns       393226 ns         1780 bytes_per_second=1.14125G/s txt4
BM_UValidate/10                  21127 ns        21127 ns        33140 bytes_per_second=5.2276G/s pb
BM_UValidate/11                 104744 ns       104743 ns         6661 bytes_per_second=1.63889G/s gaviota
BM_UValidateMedley             1404832 ns      1404792 ns          498 bytes_per_second=1.94153G/s
BM_UIOVecSource/0               100416 ns       100410 ns         6875 bytes_per_second=972.58M/s html (22.24 %)
BM_UIOVecSource/1              1356688 ns      1356630 ns          514 bytes_per_second=493.548M/s urls (47.84 %)
BM_UIOVecSource/2                11285 ns        11284 ns        62025 bytes_per_second=10.1591G/s jpg (99.95 %)
BM_UIOVecSource/3                  403 ns          403 ns      1737215 bytes_per_second=473.248M/s jpg_200 (73.00 %)
BM_UIOVecSource/4                15480 ns        15479 ns        44600 bytes_per_second=6.16095G/s pdf (83.31 %)
BM_UIOVecSource/5               443525 ns       443526 ns         1579 bytes_per_second=880.726M/s html4 (22.52 %)
BM_UIOVecSource/6               416887 ns       416888 ns         1674 bytes_per_second=347.919M/s txt1 (57.87 %)
BM_UIOVecSource/7               367795 ns       367788 ns         1897 bytes_per_second=324.589M/s txt2 (62.02 %)
BM_UIOVecSource/8              1122323 ns      1122296 ns          621 bytes_per_second=362.635M/s txt3 (55.17 %)
BM_UIOVecSource/9              1521115 ns      1521100 ns          459 bytes_per_second=302.109M/s txt4 (66.41 %)
BM_UIOVecSource/10               90887 ns        90884 ns         7284 bytes_per_second=1.21522G/s pb (19.61 %)
BM_UIOVecSource/11              355515 ns       355494 ns         1955 bytes_per_second=494.47M/s gaviota (37.73 %)
BM_UIOVecSink/0                 102119 ns       102117 ns         6789 bytes_per_second=956.317M/s html
BM_UIOVecSink/1                 954436 ns       954395 ns          732 bytes_per_second=701.557M/s urls
BM_UIOVecSink/2                   4269 ns         4268 ns       163990 bytes_per_second=26.8576G/s jpg
BM_UIOVecSink/3                    322 ns          322 ns      2176041 bytes_per_second=592.941M/s jpg_200
BM_UIOVecSink/4                   9806 ns         9806 ns        70545 bytes_per_second=9.72553G/s pdf
BM_UFlatSink/0                   30576 ns        30575 ns        22895 bytes_per_second=3.11908G/s html
BM_UFlatSink/1                  333363 ns       333353 ns         2100 bytes_per_second=1.96149G/s urls
BM_UFlatSink/2                    3912 ns         3912 ns       179331 bytes_per_second=29.3047G/s jpg
BM_UFlatSink/3                     164 ns          164 ns      4279427 bytes_per_second=1.13813G/s jpg_200
BM_UFlatSink/4                    5887 ns         5887 ns       118969 bytes_per_second=16.1991G/s pdf
BM_UFlatSink/5                  123255 ns       123252 ns         5678 bytes_per_second=3.09504G/s html4
BM_UFlatSink/6                  131130 ns       131125 ns         5337 bytes_per_second=1106.15M/s txt1
BM_UFlatSink/7                  115091 ns       115091 ns         6082 bytes_per_second=1037.27M/s txt2
BM_UFlatSink/8                  344551 ns       344539 ns         2032 bytes_per_second=1.15356G/s txt3
BM_UFlatSink/9                  476420 ns       476406 ns         1470 bytes_per_second=964.595M/s txt4
BM_UFlatSink/10                  26246 ns        26245 ns        26672 bytes_per_second=4.20819G/s pb
BM_UFlatSink/11                 140879 ns       140876 ns         4969 bytes_per_second=1.21853G/s gaviota
BM_ZFlat/0                       96401 ns        96399 ns         7125 bytes_per_second=1013.05M/s html (22.24 %)
BM_ZFlat/1                     1340286 ns      1340246 ns          521 bytes_per_second=499.582M/s urls (47.84 %)
BM_ZFlat/2                        6642 ns         6642 ns       104924 bytes_per_second=17.2593G/s jpg (99.95 %)
BM_ZFlat/3                         328 ns          328 ns      2132317 bytes_per_second=581.917M/s jpg_200 (73.00 %)
BM_ZFlat/4                       11717 ns        11717 ns        59042 bytes_per_second=8.13935G/s pdf (83.31 %)
BM_ZFlat/5                      426496 ns       426486 ns         1640 bytes_per_second=915.914M/s html4 (22.52 %)
BM_ZFlat/6                      410613 ns       410608 ns         1699 bytes_per_second=353.241M/s txt1 (57.87 %)
BM_ZFlat/7                      362311 ns       362306 ns         1925 bytes_per_second=329.501M/s txt2 (62.02 %)
BM_ZFlat/8                     1107257 ns      1107210 ns          630 bytes_per_second=367.577M/s txt3 (55.17 %)
BM_ZFlat/9                     1501667 ns      1501631 ns          465 bytes_per_second=306.026M/s txt4 (66.41 %)
BM_ZFlat/10                      84528 ns        84526 ns         7952 bytes_per_second=1.30663G/s pb (19.61 %)
BM_ZFlat/11                     344650 ns       344638 ns         2015 bytes_per_second=510.046M/s gaviota (37.73 %)
BM_ZFlatAll                    5899360 ns      5899251 ns          117 bytes_per_second=473.433M/s 12 kTestDataFiles
BM_ZFlatIncreasingTableSize      33096 ns        33095 ns        20889 bytes_per_second=936.885M/s 7 tables
```

Old Perf:
```
BM_UFlat/0                       69285 ns        69281 ns        10087 bytes_per_second=1.37653G/s html
BM_UFlat/1                      766096 ns       766034 ns          912 bytes_per_second=874.063M/s urls
BM_UFlat/2                        4035 ns         4034 ns       173510 bytes_per_second=28.4167G/s jpg
BM_UFlat/3                         187 ns          187 ns      3735588 bytes_per_second=1018.67M/s jpg_200
BM_UFlat/4                       10363 ns        10362 ns        67529 bytes_per_second=9.20333G/s pdf
BM_UFlat/5                      281146 ns       281130 ns         2490 bytes_per_second=1.35692G/s html4
BM_UFlat/6                      268610 ns       268601 ns         2606 bytes_per_second=539.996M/s txt1
BM_UFlat/7                      239866 ns       239857 ns         2918 bytes_per_second=497.713M/s txt2
BM_UFlat/8                      708861 ns       708790 ns          988 bytes_per_second=574.196M/s txt3
BM_UFlat/9                      997750 ns       997631 ns          702 bytes_per_second=460.63M/s txt4
BM_UFlat/10                      64658 ns        64652 ns        10825 bytes_per_second=1.70827G/s pb
BM_UFlat/11                     246468 ns       246451 ns         2841 bytes_per_second=713.251M/s gaviota
BM_UFlatMedley                 3675635 ns      3675264 ns          190 bytes_per_second=759.919M/s
BM_UValidate/0                   21020 ns        21018 ns        32769 bytes_per_second=4.53746G/s html
BM_UValidate/1                  343949 ns       343920 ns         2032 bytes_per_second=1.90122G/s urls
BM_UValidate/2                     138 ns          138 ns      5060369 bytes_per_second=828.669G/s jpg
BM_UValidate/3                    96.5 ns         96.5 ns      7259557 bytes_per_second=1.93099G/s jpg_200
BM_UValidate/4                    1971 ns         1971 ns       355117 bytes_per_second=48.3824G/s pdf
BM_UValidate/5                  107708 ns       107704 ns         6453 bytes_per_second=3.54185G/s html4
BM_UValidate/6                  126669 ns       126662 ns         5503 bytes_per_second=1.11829G/s txt1
BM_UValidate/7                  115561 ns       115555 ns         6048 bytes_per_second=1033.1M/s txt2
BM_UValidate/8                  335215 ns       335177 ns         2084 bytes_per_second=1.18578G/s txt3
BM_UValidate/9                  485964 ns       485937 ns         1440 bytes_per_second=945.675M/s txt4
BM_UValidate/10                  17975 ns        17974 ns        38397 bytes_per_second=6.14461G/s pb
BM_UValidate/11                  92493 ns        92484 ns         7493 bytes_per_second=1.85612G/s gaviota
BM_UValidateMedley             1698160 ns      1697991 ns          412 bytes_per_second=1.60628G/s
BM_UIOVecSource/0               110784 ns       110774 ns         6189 bytes_per_second=881.582M/s html (22.24 %)
BM_UIOVecSource/1              1404417 ns      1404231 ns          497 bytes_per_second=476.818M/s urls (47.84 %)
BM_UIOVecSource/2                11290 ns        11290 ns        61909 bytes_per_second=10.1543G/s jpg (99.95 %)
BM_UIOVecSource/3                  401 ns          401 ns      1740294 bytes_per_second=475.167M/s jpg_200 (73.00 %)
BM_UIOVecSource/4                15506 ns        15505 ns        44572 bytes_per_second=6.15058G/s pdf (83.31 %)
BM_UIOVecSource/5               468629 ns       468574 ns         1489 bytes_per_second=833.645M/s html4 (22.52 %)
BM_UIOVecSource/6               435987 ns       435960 ns         1602 bytes_per_second=332.699M/s txt1 (57.87 %)
BM_UIOVecSource/7               379021 ns       378988 ns         1842 bytes_per_second=314.997M/s txt2 (62.02 %)
BM_UIOVecSource/8              1176435 ns      1176304 ns          593 bytes_per_second=345.986M/s txt3 (55.17 %)
BM_UIOVecSource/9              1542281 ns      1542143 ns          453 bytes_per_second=297.987M/s txt4 (66.41 %)
BM_UIOVecSource/10              100702 ns       100698 ns         6639 bytes_per_second=1123.1M/s pb (19.61 %)
BM_UIOVecSource/11              378524 ns       378494 ns         1843 bytes_per_second=464.423M/s gaviota (37.73 %)
BM_UIOVecSink/0                 104544 ns       104537 ns         6634 bytes_per_second=934.175M/s html
BM_UIOVecSink/1                 953243 ns       953153 ns          732 bytes_per_second=702.471M/s urls
BM_UIOVecSink/2                   4278 ns         4278 ns       163680 bytes_per_second=26.7987G/s jpg
BM_UIOVecSink/3                    321 ns          321 ns      2178453 bytes_per_second=593.574M/s jpg_200
BM_UIOVecSink/4                   9939 ns         9939 ns        69671 bytes_per_second=9.59571G/s pdf
BM_UFlatSink/0                   69330 ns        69325 ns        10097 bytes_per_second=1.37566G/s html
BM_UFlatSink/1                  766792 ns       766679 ns          911 bytes_per_second=873.328M/s urls
BM_UFlatSink/2                    3989 ns         3989 ns       175402 bytes_per_second=28.7414G/s jpg
BM_UFlatSink/3                     193 ns          193 ns      3632512 bytes_per_second=990.14M/s jpg_200
BM_UFlatSink/4                   10414 ns        10413 ns        67175 bytes_per_second=9.15846G/s pdf
BM_UFlatSink/5                  281174 ns       281148 ns         2490 bytes_per_second=1.35683G/s html4
BM_UFlatSink/6                  268597 ns       268580 ns         2606 bytes_per_second=540.038M/s txt1
BM_UFlatSink/7                  239854 ns       239832 ns         2919 bytes_per_second=497.765M/s txt2
BM_UFlatSink/8                  709052 ns       709044 ns          987 bytes_per_second=573.99M/s txt3
BM_UFlatSink/9                  998252 ns       998199 ns          701 bytes_per_second=460.368M/s txt4
BM_UFlatSink/10                  64567 ns        64561 ns        10834 bytes_per_second=1.71068G/s pb
BM_UFlatSink/11                 246419 ns       246401 ns         2840 bytes_per_second=713.396M/s gaviota
BM_ZFlat/0                      105792 ns       105784 ns         6501 bytes_per_second=923.169M/s html (22.24 %)
BM_ZFlat/1                     1385136 ns      1385007 ns          503 bytes_per_second=483.436M/s urls (47.84 %)
BM_ZFlat/2                        6665 ns         6665 ns       104897 bytes_per_second=17.2005G/s jpg (99.95 %)
BM_ZFlat/3                         333 ns          333 ns      2100000 bytes_per_second=572.702M/s jpg_200 (73.00 %)
BM_ZFlat/4                       11734 ns        11733 ns        58718 bytes_per_second=8.12806G/s pdf (83.31 %)
BM_ZFlat/5                      454034 ns       454014 ns         1539 bytes_per_second=860.381M/s html4 (22.52 %)
BM_ZFlat/6                      429958 ns       429920 ns         1622 bytes_per_second=337.373M/s txt1 (57.87 %)
BM_ZFlat/7                      374359 ns       374345 ns         1865 bytes_per_second=318.904M/s txt2 (62.02 %)
BM_ZFlat/8                     1161529 ns      1161412 ns          601 bytes_per_second=350.422M/s txt3 (55.17 %)
BM_ZFlat/9                     1522178 ns      1522169 ns          459 bytes_per_second=301.897M/s txt4 (66.41 %)
BM_ZFlat/10                      98833 ns        98829 ns         6839 bytes_per_second=1.11752G/s pb (19.61 %)
BM_ZFlat/11                     371033 ns       371013 ns         1882 bytes_per_second=473.787M/s gaviota (37.73 %)
BM_ZFlatAll                    6109015 ns      6108341 ns          113 bytes_per_second=457.228M/s 12 kTestDataFiles
BM_ZFlatIncreasingTableSize      34125 ns        34123 ns        20220 bytes_per_second=908.652M/s 7 tables
```

Most tests are either the same or better (often MUCH better). The only regressions are some of the validation tests, especially the ones that are already well over 1GB/s. Some of the validations are also faster, including the ValidateMedley test (1.60 -> 1.94GB/s). I tracked that down to a single change, and there is already a comment saying that the intent is to get the new codegen.