### PR TITLE
Update version number to 1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 cmake_minimum_required(VERSION 3.1)
-project(Snappy VERSION 1.1.10 LANGUAGES C CXX)
+project(Snappy VERSION 1.2.0 LANGUAGES C CXX)
 
 # C++ standard can be overridden when this is used as a sub-project.
 if(NOT CMAKE_CXX_STANDARD)


### PR DESCRIPTION
[1.2.0 was released recently](https://github.com/google/snappy/releases/tag/1.2.0), but the version number was not updated, causing some inconsistency for the soname of the dynamic shared library.