### PR TITLE
chore(bazel): add MODULE.bazel files for bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,4 @@
 # googletest requires C++14 or above
 build --cxxopt='-std=c++17'
+# Enable Bzlmod for every Bazel command
+common --enable_bzlmod

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 # Build directory.
 build/
 /bazel-*
+MODULE.bazel.lock
 out/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,7 +40,7 @@ config_setting(
 cc_library(
     name = "config",
     hdrs = ["config.h"],
-    defines = ["HAVE_CONFIG_H"]
+    defines = ["HAVE_CONFIG_H"],
 )
 
 cc_library(
@@ -70,10 +70,11 @@ cc_library(
         "snappy-sinksource.h",
     ],
     copts = select({
-      ":windows": [],
-      "//conditions:default": [
-        "-Wno-sign-compare",
-    ]}),
+        ":windows": [],
+        "//conditions:default": [
+            "-Wno-sign-compare",
+        ],
+    }),
     deps = [
         ":config",
         ":snappy-stubs-internal",
@@ -114,7 +115,7 @@ cc_test(
     deps = [
         ":snappy",
         ":snappy-test",
-        "//third_party/benchmark:benchmark_main",
+        "@com_google_benchmark//:benchmark_main",
     ],
 )
 
@@ -127,7 +128,7 @@ cc_test(
     deps = [
         ":snappy",
         ":snappy-test",
-        "//third_party/googletest:gtest_main",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,23 @@
+module(
+    name = "snappy",
+    version = "1.2.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "googletest",
+    version = "1.14.0.bcr.1",
+    dev_dependency = True,
+    repo_name = "com_google_googletest",
+)
+bazel_dep(
+    name = "google_benchmark",
+    version = "1.8.3",
+    dev_dependency = True,
+    repo_name = "com_google_benchmark",
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.9",
+)


### PR DESCRIPTION
This is related to https://github.com/bazelbuild/bazel-central-registry/pull/1818

This help declare snappy as a module for other project to use .
It follows  https://bazel.build/external/migration guide

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
