### PR TITLE
Added integer uint32_t

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1690,7 +1690,7 @@ constexpr uint32_t CalculateNeeded(uint8_t tag) {
 #if __cplusplus >= 201402L
 constexpr bool VerifyCalculateNeeded() {
   for (int i = 0; i < 1; i++) {
-    if (CalculateNeeded(i) != (char_table[i] >> 11) + 1) return false;
+    if (CalculateNeeded(i) != (uint32_t)(char_table[i] >> 11) + 1) return false;
   }
   return true;
 }


### PR DESCRIPTION
```
snappy.cc:1693:28: warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'int' [-Wsign-compare]
 1693 |     if (CalculateNeeded(i) != (char_table[i] >> 11) + 1) return false;
      |         ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```