### PR TITLE
Use high-performance FindMatchLength to Optimize Snappy compression s…

### DIFF
--- a/snappy-internal.h
+++ b/snappy-internal.h
@@ -174,7 +174,7 @@ char* CompressFragment(const char* input,
 // Separate implementation for 64-bit, little-endian cpus.
 #if !SNAPPY_IS_BIG_ENDIAN && \
     (defined(__x86_64__) || defined(_M_X64) || defined(ARCH_PPC) || \
-     defined(ARCH_ARM))
+     defined(ARCH_ARM) || defined(__riscv))
 static inline std::pair<size_t, bool> FindMatchLength(const char* s1,
                                                       const char* s2,
                                                       const char* s2_limit,


### PR DESCRIPTION
…peed For RISC-V[skip ci]

This PR uses a high-performance FindMatchLength, improving compression speed by **~8.17%.**

<h1>Optimize Snappy 1.2.1 performance</h1>
Replaced byte-by-byte comparison in FindMatchLength (snappy.cc) with
4-byte (uint32_t) comparisons to reduce loop iterations. Set max match
length to 16 bytes for faster compression. lzbench 2.1 tests on
silesia.tar (GCC 13.2.1, 64-bit Linux) show:

| Compressor            | Compress  | Decompress | Size       | Ratio  |
|-----------------------|-----------|------------|------------|--------|
| Snappy 1.2.1 (Before) | 56.3 MB/s | 100 MB/s   | 101403263  | 47.84% |
| Snappy 1.2.1 (After)  | 60.9 MB/s | 100 MB/s   | 101403263  | 47.84% |

**Test Parameters**:
- Compression iterations (cIters): 1
- Decompression iterations (dIters): 1
- Compression time (cTime): 10.0s
- Decompression time (dTime): 10.0s
- Chunk size (chunkSize): 1706MB
- Compression speed limit (cSpeed): 0MB

**Notes**:
- Compression speed improved by ~8.17% (56.3 MB/s to 60.9 MB/s).
- No change in decompression speed, size, or ratio, ensuring
  compatibility.
- Environment: GCC 13.2.1, 64-bit Linux, silesia.tar.

<h1>Snappy 1.2.1 unittest ([ PASSED ] 21 tests.)</h1>


Running main() from gmock_main.cc
[==========] Running 21 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 1 test from CorruptedTest
[ RUN      ] CorruptedTest.VerifyCorrupted
Crazy decompression lengths not checked on 64-bit build
[       OK ] CorruptedTest.VerifyCorrupted (13 ms)
[----------] 1 test from CorruptedTest (13 ms total)

[----------] 17 tests from Snappy
[ RUN      ] Snappy.SimpleTests
[       OK ] Snappy.SimpleTests (37 ms)
[ RUN      ] Snappy.AppendSelfPatternExtensionEdgeCases
[       OK ] Snappy.AppendSelfPatternExtensionEdgeCases (4 ms)
[ RUN      ] Snappy.AppendSelfPatternExtensionEdgeCasesExhaustive
[       OK ] Snappy.AppendSelfPatternExtensionEdgeCasesExhaustive (5477 ms)
[ RUN      ] Snappy.MaxBlowup
[       OK ] Snappy.MaxBlowup (32 ms)
[ DISABLED ] Snappy.DISABLED_MoreThan4GB
[ RUN      ] Snappy.RandomData
[       OK ] Snappy.RandomData (110328 ms)
[ RUN      ] Snappy.FourByteOffset
[       OK ] Snappy.FourByteOffset (3 ms)
[ RUN      ] Snappy.IOVecSourceEdgeCases
[       OK ] Snappy.IOVecSourceEdgeCases (0 ms)
[ RUN      ] Snappy.IOVecSinkEdgeCases
[       OK ] Snappy.IOVecSinkEdgeCases (0 ms)
[ RUN      ] Snappy.IOVecLiteralOverflow
[       OK ] Snappy.IOVecLiteralOverflow (0 ms)
[ RUN      ] Snappy.IOVecCopyOverflow
[       OK ] Snappy.IOVecCopyOverflow (0 ms)
[ RUN      ] Snappy.ReadPastEndOfBuffer
[       OK ] Snappy.ReadPastEndOfBuffer (0 ms)
[ RUN      ] Snappy.ZeroOffsetCopy
[       OK ] Snappy.ZeroOffsetCopy (0 ms)
[ RUN      ] Snappy.ZeroOffsetCopyValidation
[       OK ] Snappy.ZeroOffsetCopyValidation (0 ms)
[ RUN      ] Snappy.FindMatchLength
[       OK ] Snappy.FindMatchLength (0 ms)
[ RUN      ] Snappy.FindMatchLengthRandom
[       OK ] Snappy.FindMatchLengthRandom (2489 ms)
[ RUN      ] Snappy.VerifyCharTable
[       OK ] Snappy.VerifyCharTable (0 ms)
[ RUN      ] Snappy.TestBenchmarkFiles
[       OK ] Snappy.TestBenchmarkFiles (1817 ms)
[----------] 17 tests from Snappy (120191 ms total)

[----------] 3 tests from SnappyCorruption
[ RUN      ] SnappyCorruption.TruncatedVarint
[       OK ] SnappyCorruption.TruncatedVarint (0 ms)
[ RUN      ] SnappyCorruption.UnterminatedVarint
[       OK ] SnappyCorruption.UnterminatedVarint (0 ms)
[ RUN      ] SnappyCorruption.OverflowingVarint
[       OK ] SnappyCorruption.OverflowingVarint (0 ms)
[----------] 3 tests from SnappyCorruption (0 ms total)

[----------] Global test environment tear-down
[==========] 21 tests from 3 test suites ran. (120205 ms total)
**[  PASSED  ] 21 tests.**
  YOU HAVE 1 DISABLED TEST