### PR TITLE
Move `//:config` to `implementation_deps` to prevent header collision

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -62,8 +62,10 @@ cc_library(
     name = "snappy-stubs-internal",
     srcs = ["snappy-stubs-internal.cc"],
     hdrs = ["snappy-stubs-internal.h"],
-    deps = [
+    implementation_deps = [
         ":config",
+    ],
+    deps = [
         ":snappy-stubs-public",
     ],
 )
@@ -85,8 +87,10 @@ cc_library(
             "-Wno-sign-compare",
         ],
     }),
-    deps = [
+    implementation_deps = [
         ":config",
+    ],
+    deps = [
         ":snappy-stubs-internal",
         ":snappy-stubs-public",
     ],


### PR DESCRIPTION
Snappy's `//:config` target exposes `config.h` via `hdrs` and defines `HAVE_CONFIG_H`. Whenever `//:snappy` is in the dependency graph of any other `cc_*` target it results in snappy's `config.h` being added as an available header to compile actions. This leads to a header collision and breaks consumers. By moving `//:config` to [implementation_deps](https://bazel.build/reference/be/c-cpp#cc_library.implementation_deps) the header is not propagated and the collision is avoided.