### PR TITLE
perf: replace post-increment/decrement with pre-increment/decrement

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -362,7 +362,7 @@ static inline bool Copy64BytesWithPatternExtension(char* dst, size_t offset) {
         // TODO: Ideally we should memset, move back once the
         // codegen issues are fixed.
         V128 pattern = V128_DupChar(dst[-1]);
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; ++i) {
           V128_StoreU(reinterpret_cast<V128*>(dst + 16 * i), pattern);
         }
         return true;
@@ -372,7 +372,7 @@ static inline bool Copy64BytesWithPatternExtension(char* dst, size_t offset) {
       case 8:
       case 16: {
         V128 pattern = LoadPattern(dst - offset, offset);
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; ++i) {
           V128_StoreU(reinterpret_cast<V128*>(dst + 16 * i), pattern);
         }
         return true;
@@ -382,7 +382,7 @@ static inline bool Copy64BytesWithPatternExtension(char* dst, size_t offset) {
             LoadPatternAndReshuffleMask(dst - offset, offset);
         V128 pattern = pattern_and_reshuffle_mask.first;
         V128 reshuffle_mask = pattern_and_reshuffle_mask.second;
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; ++i) {
           V128_StoreU(reinterpret_cast<V128*>(dst + 16 * i), pattern);
           pattern = V128_Shuffle(pattern, reshuffle_mask);
         }
@@ -395,15 +395,15 @@ static inline bool Copy64BytesWithPatternExtension(char* dst, size_t offset) {
     if (SNAPPY_PREDICT_FALSE(offset == 0)) return false;
     // Extend the pattern to the first 16 bytes.
     // The simpler formulation of `dst[i - offset]` induces undefined behavior.
-    for (int i = 0; i < 16; i++) dst[i] = (dst - offset)[i];
+    for (int i = 0; i < 16; ++i) dst[i] = (dst - offset)[i];
     // Find a multiple of pattern >= 16.
     static std::array<uint8_t, 16> pattern_sizes = []() {
       std::array<uint8_t, 16> res;
-      for (int i = 1; i < 16; i++) res[i] = (16 / i + 1) * i;
+      for (int i = 1; i < 16; ++i) res[i] = (16 / i + 1) * i;
       return res;
     }();
     offset = pattern_sizes[offset];
-    for (int i = 1; i < 4; i++) {
+    for (int i = 1; i < 4; ++i) {
       std::memcpy(dst + i * 16, dst + i * 16 - offset, 16);
     }
     return true;
@@ -411,7 +411,7 @@ static inline bool Copy64BytesWithPatternExtension(char* dst, size_t offset) {
 #endif  // SNAPPY_HAVE_VECTOR_BYTE_SHUFFLE
 
   // Very rare.
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 4; ++i) {
     std::memcpy(dst + i * 16, dst + i * 16 - offset, 16);
   }
   return true;
@@ -982,7 +982,7 @@ char* CompressFragmentDoubleHash(const char* input, size_t input_size, char* op,
         assert(static_cast<uint32_t>(data) == LittleEndian::Load32(ip));
         uint16_t* table_entry2 = TableEntry8ByteMatch(table2, data, mask);
         uint32_t bytes_between_hash_lookups = skip >> 9;
-        skip++;
+        ++skip;
         const char* next_ip = ip + bytes_between_hash_lookups;
         if (SNAPPY_PREDICT_FALSE(next_ip > ip_limit)) {
           ip = next_emit;
@@ -1408,7 +1408,7 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
   op_limit_min_slop -= kSlopBytes;
   if (2 * (kSlopBytes + 1) < ip_limit - ip && op < op_limit_min_slop) {
     const uint8_t* const ip_limit_min_slop = ip_limit - 2 * kSlopBytes - 1;
-    ip++;
+    ++ip;
     // ip points just past the tag and we are touching at maximum kSlopBytes
     // in an iteration.
     size_t tag = ip[-1];
@@ -1427,7 +1427,7 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
       // leads to reduced mov's.
 
       SNAPPY_PREFETCH(ip + 128);
-      for (int i = 0; i < 2; i++) {
+      for (int i = 0; i < 2; ++i) {
         const uint8_t* old_ip = ip;
         assert(tag == ip[-1]);
         // For literals tag_type = 0, hence we will always obtain 0 from
@@ -1495,7 +1495,7 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
     } while (ip < ip_limit_min_slop &&
              static_cast<ptrdiff_t>(op + deferred_length) < op_limit_min_slop);
   exit:
-    ip--;
+    --ip;
     assert(ip <= ip_limit);
   }
   // If we deferred a copy then we can perform.  If we are up to date then we
@@ -1614,7 +1614,7 @@ class SnappyDecompressor {
         }
       }
       const uint8_t c = static_cast<uint8_t>(preload);
-      ip++;
+      ++ip;
 
       // Ratio of iterations that have LITERAL vs non-LITERAL for different
       // inputs.
@@ -1707,7 +1707,7 @@ constexpr uint32_t CalculateNeeded(uint8_t tag) {
 
 #if __cplusplus >= 201402L
 constexpr bool VerifyCalculateNeeded() {
-  for (int i = 0; i < 1; i++) {
+  for (int i = 0; i < 1; ++i) {
     if (CalculateNeeded(i) != static_cast<uint32_t>((char_table[i] >> 11)) + 1)
       return false;
   }
@@ -2573,7 +2573,7 @@ bool SnappyScatteredWriter<Allocator>::SlowAppendFromSelf(size_t offset,
       op_ptr_ = op;
       return false;
     }
-    src++;
+    ++src;
   }
   op_ptr_ = op;
   return true;

--- a/snappy_benchmark.cc
+++ b/snappy_benchmark.cc
@@ -81,7 +81,7 @@ BENCHMARK(BM_UFlat)->Apply(FilesAndLevels);
 
 struct SourceFiles {
   SourceFiles() {
-    for (int i = 0; i < kFiles; i++) {
+    for (int i = 0; i < kFiles; ++i) {
       std::string contents = ReadTestDataFile(kTestDataFiles[i].filename,
                                               kTestDataFiles[i].size_limit);
       max_size = std::max(max_size, contents.size());
@@ -101,7 +101,7 @@ void BM_UFlatMedley(benchmark::State& state) {
   std::vector<char> dst(source->max_size);
 
   for (auto s : state) {
-    for (int i = 0; i < SourceFiles::kFiles; i++) {
+    for (int i = 0; i < SourceFiles::kFiles; ++i) {
       CHECK(snappy::RawUncompress(source->zcontents[i].data(),
                                   source->zcontents[i].size(), dst.data()));
       benchmark::DoNotOptimize(dst);
@@ -109,7 +109,7 @@ void BM_UFlatMedley(benchmark::State& state) {
   }
 
   int64_t source_sizes = 0;
-  for (int i = 0; i < SourceFiles::kFiles; i++) {
+  for (int i = 0; i < SourceFiles::kFiles; ++i) {
     source_sizes += static_cast<int64_t>(source->sizes[i]);
   }
   state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *
@@ -145,14 +145,14 @@ void BM_UValidateMedley(benchmark::State& state) {
   static const SourceFiles* const source = new SourceFiles();
 
   for (auto s : state) {
-    for (int i = 0; i < SourceFiles::kFiles; i++) {
+    for (int i = 0; i < SourceFiles::kFiles; ++i) {
       CHECK(snappy::IsValidCompressedBuffer(source->zcontents[i].data(),
                                             source->zcontents[i].size()));
     }
   }
 
   int64_t source_sizes = 0;
-  for (int i = 0; i < SourceFiles::kFiles; i++) {
+  for (int i = 0; i < SourceFiles::kFiles; ++i) {
     source_sizes += static_cast<int64_t>(source->sizes[i]);
   }
   state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *

--- a/snappy_unittest.cc
+++ b/snappy_unittest.cc
@@ -310,8 +310,8 @@ TEST(CorruptedTest, VerifyCorrupted) {
   // Mess around with the data. It's hard to simulate all possible
   // corruptions; this is just one example ...
   CHECK_GT(dest.size(), 3);
-  dest[1]--;
-  dest[3]++;
+  --dest[1];
+  ++dest[3];
   // this really ought to fail.
   CHECK(!IsValidCompressedBuffer(dest));
   CHECK(!Uncompress(dest, &uncmp));
@@ -947,7 +947,7 @@ TEST(Snappy, VerifyCharTable) {
   // Small LITERAL entries.  We store (len-1) in the top 6 bits.
   for (uint8_t len = 1; len <= 60; ++len) {
     dst[LITERAL | ((len - 1) << 2)] = MakeEntry(0, len, 0);
-    assigned++;
+    ++assigned;
   }
 
   // Large LITERAL entries.  We use 60..63 in the high 6 bits to
@@ -956,7 +956,7 @@ TEST(Snappy, VerifyCharTable) {
     // We set the length field in the lookup table to 1 because extra
     // bytes encode len-1.
     dst[LITERAL | ((extra_bytes + 59) << 2)] = MakeEntry(extra_bytes, 1, 0);
-    assigned++;
+    ++assigned;
   }
 
   // COPY_1_BYTE_OFFSET.
@@ -971,7 +971,7 @@ TEST(Snappy, VerifyCharTable) {
       uint8_t offset_high = static_cast<uint8_t>(offset >> 8);
       dst[COPY_1_BYTE_OFFSET | ((len - 4) << 2) | (offset_high << 5)] =
           MakeEntry(1, len, offset_high);
-      assigned++;
+      ++assigned;
     }
   }
 
@@ -979,14 +979,14 @@ TEST(Snappy, VerifyCharTable) {
   // Tag contains len-1 in top 6 bits, and offset in next two bytes.
   for (uint8_t len = 1; len <= 64; ++len) {
     dst[COPY_2_BYTE_OFFSET | ((len - 1) << 2)] = MakeEntry(2, len, 0);
-    assigned++;
+    ++assigned;
   }
 
   // COPY_4_BYTE_OFFSET.
   // Tag contents len-1 in top 6 bits, and offset in next four bytes.
   for (uint8_t len = 1; len <= 64; ++len) {
     dst[COPY_4_BYTE_OFFSET | ((len - 1) << 2)] = MakeEntry(4, len, 0);
-    assigned++;
+    ++assigned;
   }
 
   // Check that each entry was initialized exactly once.


### PR DESCRIPTION
### Performance Improvement: Pre-Increment/Decrement

Replaced **post-increment** (`i++`) and **post-decrement** (`i--`) operators  
with **pre-increment** (`++i`) and **pre-decrement** (`--i`) operators where applicable to improve performance.

#### Why this change matters
- Pre-increment/decrement avoids creating unnecessary temporary values.
- Helps optimize loops and frequently executed operations.
- Maintains the same logic and behavior as before.

#### Affected code
- All instances of `i++` and `i--` where pre-increment/decrement can safely be used.