### PR TITLE
RISC-V：Optimize decompression throughput by mirroring AVX fast-path for RVV short memcpy +15%

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1244,24 +1244,22 @@ void MemCopy64(char* dst, const void* src, size_t size) {
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst) + 1, data);
   }
   // RVV acceleration available on RISC-V when compiled with -march=rv64gcv
+  // RVV: mirror the AVX path — first 32 B, then another 32 B if size > 32.
+  // e8m1 may need two segments per 32 B when VLEN < 256 (e.g. vl=16 on VLEN=128).
 #elif defined(__riscv) && SNAPPY_HAVE_RVV
-  // Cast pointers to the type we will operate on.
-  unsigned char* dst_ptr = reinterpret_cast<unsigned char*>(dst);
-  const unsigned char* src_ptr = reinterpret_cast<const unsigned char*>(src);
-  size_t remaining_bytes = size;
-  // Loop as long as there are bytes remaining to be copied.
-  while (remaining_bytes > 0) {
-    // Set vector configuration: e8 (8-bit elements), m2 (LMUL=2).
-    // Use e8m2 configuration to maximize throughput.
-    size_t vl = VSETVL_E8M2(remaining_bytes);
-    // Load data from the current source pointer.
-    vuint8m2_t vec = VLE8_V_U8M2(src_ptr, vl);
-    // Store data to the current destination pointer.
-    VSE8_V_U8M2(dst_ptr, vec, vl);
-    // Update pointers and the remaining count.
-    src_ptr += vl;
-    dst_ptr += vl;
-    remaining_bytes -= vl;
+  assert(kShortMemCopy <= 32);
+  const size_t vl = __riscv_vsetvl_e8m2(32);
+  unsigned char* d = reinterpret_cast<unsigned char*>(dst);
+  const unsigned char* s = reinterpret_cast<const unsigned char*>(src);
+
+  vuint8m2_t v0 = __riscv_vle8_v_u8m2(s, vl);
+  __riscv_vse8_v_u8m2(d, v0, vl);
+  // Profiling shows that nearly all copies are short.
+  if (SNAPPY_PREDICT_FALSE(size > kShortMemCopy)) {
+    const unsigned char* s2 = s + kShortMemCopy;
+    unsigned char* d2 = d + kShortMemCopy;
+    vuint8m2_t v2 = __riscv_vle8_v_u8m2(s2, vl);
+    __riscv_vse8_v_u8m2(d2, v2, vl);
   }
 
 #else

--- a/snappy.cc
+++ b/snappy.cc
@@ -1244,24 +1244,21 @@ void MemCopy64(char* dst, const void* src, size_t size) {
     _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst) + 1, data);
   }
   // RVV acceleration available on RISC-V when compiled with -march=rv64gcv
+  // RVV: mirror the AVX path — first 32 B, then another 32 B if size > 32.
+  // e8m1 may need two segments per 32 B when VLEN < 256 (e.g. vl=16 on VLEN=128).
 #elif defined(__riscv) && SNAPPY_HAVE_RVV
-  // Cast pointers to the type we will operate on.
-  unsigned char* dst_ptr = reinterpret_cast<unsigned char*>(dst);
-  const unsigned char* src_ptr = reinterpret_cast<const unsigned char*>(src);
-  size_t remaining_bytes = size;
-  // Loop as long as there are bytes remaining to be copied.
-  while (remaining_bytes > 0) {
-    // Set vector configuration: e8 (8-bit elements), m2 (LMUL=2).
-    // Use e8m2 configuration to maximize throughput.
-    size_t vl = VSETVL_E8M2(remaining_bytes);
-    // Load data from the current source pointer.
-    vuint8m2_t vec = VLE8_V_U8M2(src_ptr, vl);
-    // Store data to the current destination pointer.
-    VSE8_V_U8M2(dst_ptr, vec, vl);
-    // Update pointers and the remaining count.
-    src_ptr += vl;
-    dst_ptr += vl;
-    remaining_bytes -= vl;
+  assert(kShortMemCopy <= 32);
+  const size_t vl = VSETVL_E8M2(32);
+  unsigned char* d = reinterpret_cast<unsigned char*>(dst);
+  const unsigned char* s = reinterpret_cast<const unsigned char*>(src);
+  vuint8m2_t v0 = VLE8_V_U8M2(s, vl);
+  VSE8_V_U8M2(d, v0, vl);
+  // Profiling shows that nearly all copies are short.
+  if (SNAPPY_PREDICT_FALSE(size > kShortMemCopy)) {
+    const unsigned char* s2 = s + kShortMemCopy;
+    unsigned char* d2 = d + kShortMemCopy;
+    vuint8m2_t v2 = VLE8_V_U8M2(s2, vl);
+    VSE8_V_U8M2(d2, v2, vl);
   }
 
 #else


### PR DESCRIPTION
### PR Title
**Optimize RVV memcpy path to mirror AVX fast-path for short copies**

---

### Summary
Refactors the RISC-V Vector (RVV) acceleration path in the short memcpy helper to mirror the existing AVX implementation. Instead of a generic `vsetvl` loop, this version performs a fixed 32-byte vector copy (with an optional second 32-byte segment), matching the profile-driven assumption that **nearly all copies are short**.

This eliminates loop overhead in the hot path and aligns RVV behavior with the well-tuned AVX code path.

### Performance
Tested with **lzbench** on **Spacemit(R) X60** (RISC-V, RVV 1.0):

- **Before:** 269 MB/s
- **After:** 310 MB/s
- **Improvement:** **+15%**

### Implementation Details
- Uses `__riscv_vsetvl_e8m2(32)` to configure a 32-byte vector operation, matching the `kShortMemCopy` constant used in the AVX path.
- Performs an unconditional first 32-byte load/store.
- A second 32-byte segment is conditionally executed (with `SNAPPY_PREDICT_FALSE`) only when `size > kShortMemCopy`, since profiling shows long copies are rare.
- Note: with `e8m1` and `VLEN < 256` (e.g., `VLEN=128`, `vl=16`), two segments per 32 B would be required; using `e8m2` ensures 32 B per op on common configurations.



### Verification
- Environment: **Spacemit(R) X60** (RISC-V, RVV 1.0)
- Benchmark tool: **lzbench**
- Compiled with `-march=rv64gcv`
- Passed all existing Snappy unit tests.