### PR TITLE
RISC-V: Add optimized decompression path

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1318,6 +1318,27 @@ inline size_t AdvanceToNextTagARMOptimized(const uint8_t** ip_p, size_t* tag) {
 }
 
 SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline size_t AdvanceToNextTagRISCVOptimized(const uint8_t** ip_p,
+                                              size_t* tag) {
+  const uint8_t*& ip = *ip_p;
+  // RISC-V lacks conditional-move instructions, so a straightforward branch
+  // (similar to ARM) is preferred over the x86 cmov-based approach.
+  // The latency-critical data chain is:
+  // ip -> c = Load(ip) -> delta1 = (c & 3)        -> ip += delta1 or delta2
+  //                       delta2 = ((c >> 2) + 1)    ip++
+  const size_t tag_type = *tag & 3;
+  if (tag_type == 0) {
+    size_t next_literal_tag = (*tag >> 2) + 1;
+    *tag = ip[next_literal_tag];
+    ip += next_literal_tag + 1;
+  } else {
+    *tag = ip[tag_type];
+    ip += tag_type + 1;
+  }
+  return tag_type;
+}
+
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
 inline size_t AdvanceToNextTagX86Optimized(const uint8_t** ip_p, size_t* tag) {
   const uint8_t*& ip = *ip_p;
   // This section is crucial for the throughput of the decompression loop.
@@ -1375,7 +1396,7 @@ inline uint32_t ExtractOffset(uint32_t val, size_t tag_type) {
          reinterpret_cast<const char*>(&kExtractMasksCombined) + 2 * tag_type,
          sizeof(result));
   return val & result;
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__riscv)
   constexpr uint64_t kExtractMasksCombined = 0x0000FFFF00FF0000ull;
   return val & static_cast<uint32_t>(
       (kExtractMasksCombined >> (tag_type * 16)) & 0xFFFF);
@@ -1438,6 +1459,10 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
         size_t tag_type = AdvanceToNextTagARMOptimized(&ip, &tag);
         // We never need more than 16 bits. Doing a Load16 allows the compiler
         // to elide the masking operation in ExtractOffset.
+        next = LittleEndian::Load16(old_ip);
+#elif defined(__riscv)
+        size_t tag_type = AdvanceToNextTagRISCVOptimized(&ip, &tag);
+        // RISC-V also benefits from 16-bit load like ARM.
         next = LittleEndian::Load16(old_ip);
 #else
         size_t tag_type = AdvanceToNextTagX86Optimized(&ip, &tag);


### PR DESCRIPTION
### Summary
This PR adds a RISC-V-optimized decompression path for the branchless inner loop in Snappy.  
RISC-V lacks conditional-move (`cmov`) instructions, making the existing x86-optimized `AdvanceToNextTagX86Optimized` suboptimal on RISC-V platforms.  
We introduce `AdvanceToNextTagRISCVOptimized` with a branch structure similar to ARM, and share ARM's `ExtractOffset` / `Load16` strategy.

### Motivation
The decompression loop (`DecompressBranchless`) is the hottest path for Snappy's `RawUncompress`, `Uncompress`, and validation APIs.  
- On x86_64, the loop uses `cmov` and `volatile` loads to minimize latency.  
- On ARM64, a simpler branch-based approach works better due to `csinc`.  
- RISC-V falls through to the x86 path by default, which forces the compiler to emulate `cmov` with extra register moves and branches.  

This patch gives RISC-V its own optimized path.

### Changes Made
- Added `AdvanceToNextTagRISCVOptimized()` in `snappy.cc`  
- Updated `ExtractOffset()` to include `defined(__riscv)` alongside `defined(__aarch64__)`  
- Updated `DecompressBranchless()` to use the new RISC-V path with `Load16`

### Implementation Details
- **No new dependencies**: the optimization is purely scalar, guarded by `#if defined(__riscv)`  
- **No API changes**: fully backward compatible  
- **Non-RISC-V platforms**: zero impact — all changes are behind preprocessor conditionals

### Performance Results

**Test Environment**  
- Hardware: Banana Pi K1 (SpacemiT X60)  
- CPU: 8-core X60 @ 1.6GHz
- Compiler: Clang 17+ / GCC 13+ with `-march=rv64gcv`

#### BM_UFlat (Decompression) – Core Improvement

| Benchmark | Before (ns) | After (ns) | Speedup | Bandwidth Gain |
|-----------|-------------|------------|---------|----------------|
| html/1    | 228,447     | 185,498    | 1.232   | +23.2% |
| html/2    | 206,562     | 168,327    | 1.227   | +22.7% |
| urls/1    | 2,703,524   | 2,221,052  | 1.217   | +21.7% |
| urls/2    | 2,500,196   | 2,057,324  | 1.215   | +21.5% |
| html4/1   | 930,183     | 762,913    | 1.219   | +21.9% |
| txt1/1    | 1,008,827   | 817,822    | 1.234   | +23.4% |
| txt2/1    | 889,770     | 724,470    | 1.228   | +22.8% |
| txt3/1    | 2,686,800   | 2,183,861  | 1.230   | +23.0% |
| txt4/1    | 3,750,967   | 3,052,873  | 1.229   | +22.9% |
| pb/1      | 201,982     | 164,958    | 1.224   | +22.4% |
| gaviota/1 | 997,243     | 822,349    | 1.213   | +21.3% |
| **Medley**| **13,674,217** | **11,192,662** | **1.222** | **+22.2%** |

#### BM_UValidate (Validation) – Consistent Gains

| Benchmark | Before (ns) | After (ns) | Speedup |
|-----------|-------------|------------|---------|
| html/1    | 141,792     | 116,440    | 1.218   |
| pdf/1     | 13,438      | 11,055     | 1.215   |
| txt1/1    | 631,535     | 516,461    | 1.223   |
| txt4/1    | 2,312,771   | 1,891,391  | 1.223   |
| pb/1      | 123,329     | 101,392    | 1.216   |
| gaviota/1 | 597,290     | 487,891    | 1.224   |
| **Medley**| **8,432,222** | **6,930,131** | **1.217** |

#### Binary Data – No Regression

| Benchmark | Before (ns) | After (ns) | Speedup | Note |
|-----------|-------------|------------|---------|------|
| jpg/1     | 27,303      | 27,755     | 0.984   | -1.6% (within measurement noise) |
| jpg/2     | 26,663      | 26,757     | 0.996   | -0.4% (within measurement noise) |
| jpg_200/1 | 1,138       | 1,130      | 1.007   | +0.7% |
| pdf/1     | 38,860      | 36,969     | 1.051   | +5.1% |
| pdf/2     | 84,765      | 75,830     | 1.118   | +11.8% |

#### Other Operations

| Operation          | Result                        | Assessment                |
|--------------------|-------------------------------|---------------------------|
| BM_UFlatSink       | +22~23% on text               | Consistent with UFlat     |
| BM_ZFlat           | ±2%                           | No impact on compression  |
| BM_UIOVecSource    | <3% variance                  | No regression             |
| BM_UIOVecSink      | <2% variance                  | No regression             |

### Test Repeatability
Three independent runs confirm stable and reproducible results.  
All text workloads show consistently **+21~23% improvement**; binary workloads show **<2% variance** (within measurement noise).

### Compatibility & Portability

| Platform                     | Behavior                                    |
|------------------------------|---------------------------------------------|
| RISC-V (`__riscv` defined)   | Uses new optimized path                     |
| Non-RISC-V (x86_64, ARM64)   | Completely unaffected — code is behind `#if defined(__riscv)` |

### Testing
- [x] `snappy_unittest` passes all tests  
- [x] `snappy_benchmark` verified on RISC-V hardware (Banana Pi K1)  
- [x] No regressions on existing platforms (CI verified)

### Checklist
- [x] Code follows project’s C++ style  
- [x] Comments added for non-obvious logic  
- [x] Performance data included with multiple test runs  
- [x] Full backward compatibility maintained  
- [x] No breaking changes to API or behavior  
- [x] All existing unit tests pass

---

### Screenshots

**Unit Tests - All Pass**  
<img width="852" height="1622" alt="u" src="https://github.com/user-attachments/assets/cd1dced4-2b04-49aa-a66a-0647dff2d54f" />

**Benchmark - Before Optimization**  
<img width="1393" height="3628" alt="CjYTPWngPK-AML2xACGOFBkSvIg189" src="https://github.com/user-attachments/assets/926ba3e7-46bb-473d-8998-c8a15d6702e6" />

**Benchmark - After Optimization**  
<img width="1496" height="3626" alt="b" src="https://github.com/user-attachments/assets/5f04c410-41a0-4eae-9331-b59df8ead175" />