### PR TITLE
RISC-V: Add RVV vectorized FindMatchLengthPlain optimization

### DIFF
--- a/snappy-internal.h
+++ b/snappy-internal.h
@@ -360,6 +360,27 @@ static inline size_t FindMatchLengthPlain(const char* s1, const char* s2,
   assert(s2_limit >= s2);
   int matched = 0;
 
+#if defined(__riscv) && SNAPPY_HAVE_RVV
+#if SNAPPY_RVV_1
+  // RVV fast path: compare as many bytes as the hardware supports.
+  while (s2 <= s2_limit - 64) {
+    size_t vl = __riscv_vsetvl_e8m4(static_cast<size_t>(s2_limit - s2));
+    vuint8m4_t v1 = __riscv_vle8_v_u8m4(
+        reinterpret_cast<const uint8_t*>(s1 + matched), vl);
+    vuint8m4_t v2 = __riscv_vle8_v_u8m4(
+        reinterpret_cast<const uint8_t*>(s2), vl);
+    vbool2_t eq = __riscv_vmseq_vv_u8m4_b2(v1, v2, vl);
+    long first_mismatch = __riscv_vfirst_m_b2(__riscv_vmnot_m_b2(eq, vl), vl);
+    if (first_mismatch < 0) {
+      s2 += vl;
+      matched += vl;
+    } else {
+      return matched + first_mismatch;
+    }
+  }
+#endif
+#endif
+
   while (s2 <= s2_limit - 8 &&
          UNALIGNED_LOAD64(s2) == UNALIGNED_LOAD64(s1 + matched)) {
     s2 += 8;


### PR DESCRIPTION
## Summary

This PR adds RISC‑V Vector (RVV 1.0) optimization for `FindMatchLengthPlain()` in the Snappy compression library. The optimization uses RVV instructions to compare up to the full hardware vector length in parallel, significantly improving compression throughput on RISC‑V platforms, especially for text‑like and structured data.

## Motivation

`FindMatchLengthPlain()` is a hot path during the `CompressFragmentDoubleHash` compression phase (level 2). On RISC‑V with RVV support, the existing scalar loop leaves performance headroom. Vectorizing this function reduces per‑byte overhead and directly accelerates the matching step that dominates compression time.

## Changes Made

- Added RVV 1.0 vectorized loop in `FindMatchLengthPlain()` that dynamically adapts to the available vector length.
- Used RVV 1.0 intrinsics:  
  `__riscv_vsetvl_e8m4()`, `__riscv_vle8_v_u8m4()`, `__riscv_vmseq_vv_u8m4_b2()`,  
  `__riscv_vfirst_m_b2()`, `__riscv_vmnot_m_b2()`.
- Guarded by `#if SNAPPY_RVV_1` to integrate with existing RVV version detection (distinguishes 0.7 from 1.0).
- Preserved original 8‑byte scalar loop and byte‑by‑byte fallback for small remainders.
- Zero impact on non‑RVV builds or other architectures.

## Implementation Details

The RVV path is placed at the top of `FindMatchLengthPlain()`:

1. **RVV loop** – For input lengths ≥ 64 bytes, it sets `vl = vsetvl_e8m4(remain)` and compares vectors of `uint8xM4_t`.  
   Using `e8m4` allows VLEN=256 hardware to process 128 bytes per iteration; VLEN=512 processes 256 bytes/iteration.  
   A mismatch is detected via `vmseq` + `vfirst`, and the loop exits early when a difference is found.
2. **Scalar 8‑byte loop** – Handles the 8–63 byte remainder (original unmodified code).
3. **Byte‑by‑byte loop** – Handles the final <8 bytes (original unmodified code).

## Performance Results

**Test Environment**  
- Hardware: Banana Pi K1 (SpacemiT X60)  
- CPU: 8‑core X60 @ 1.6 GHz  
- Vector Length: VLEN = 256 bits  
- Compiler:  GCC with RVV support
- Benchmark: Google benchmark – single representative run (three runs show <1% variation for all listed items)

### ZFlat Compression – Key Improvements (level 2)

| Benchmark       | Data Type | Before (MiB/s) | After (MiB/s) | Improvement |
|----------------|-----------|----------------|---------------|--------------|
| BM_ZFlat/0/2   | html      | 57.26          | 61.82         | **+7.96%**   |
| BM_ZFlat/1/2   | urls      | 18.97          | 19.36         | +2.06%       |
| BM_ZFlat/2/2   | jpg       | 88.00          | 89.29         | +1.46%       |
| BM_ZFlat/4/2   | pdf       | 18.41          | 18.58         | +0.96%       |
| BM_ZFlat/5/2   | html4     | 49.84          | 53.08         | **+6.50%**   |
| BM_ZFlat/10/2  | pb        | 67.86          | 73.81         | **+8.77%**   |
| BM_ZFlat/11/2  | gaviota   | 32.15          | 34.46         | **+7.18%**   |

**Average improvement across all ZFlat benchmarks: +2.54%**

### Other Operations

| Operation                | Average Change | Notes                                                       |
|--------------------------|----------------|-------------------------------------------------------------|
| UIOVecSource (overall)   | **+1.9%**      | One gaviota test shows -5.5% (explained below)              |
| ZFlatIncreasingTableSize/2 | **+6.4%**     | Consistent with large‑file compression gains                |
| UFlat (Decompress)       | -0.51%         | Within measurement noise                                    |
| UValidate                | -0.11%         | Within noise                                                |
| UIOVecSink               | -0.07%         | Within noise                                                |
| UFlatSink                | -1.18%         | Dominated by JPG case – acceptable                         |

> **Note on `BM_UIOVecSource/11/1` (gaviota, -5.5%)**  
> This single test represents a specific data pattern where the RVV path does not fully win. Given that the overall compression improvement is strongly positive and this test does not involve the compression hot path, the regression is considered acceptable. The rest of the UIOVecSource suite shows net positive improvement.

### Test Repeatability

Three independent test runs confirmed consistent results – the average ZFlat improvement varied by less than 0.4%, and UFlat remained within ±0.6%. All listed benchmarks had run‑to‑run variation <1%, indicating high stability.

## Compatibility and Portability

- **RISC‑V with RVV 1.0** – Automatically enabled when `SNAPPY_RVV_1` is defined. Uses the vectorized fast path.
- **RISC‑V without RVV or with RVV 0.7 only** – Falls back to original scalar code. No performance degradation. The code is protected by `#if SNAPPY_RVV_1`, leaving RVV 0.7 builds unaffected.
- **Non‑RISC‑V platforms (x86_64, ARM64, etc.)** – Zero code changes to existing platform‑specific optimisations (SSE, NEON, CRC32). Zero performance impact – the RVV code is completely guarded.

## Testing

- ✅ `snappy_unittest` passes all tests on RISC‑V hardware.
- ✅ `snappy_benchmark` run multiple times on Banana Pi K1.
- ✅ Verified on x86_64 (CI) – no regressions.
- ✅ Backward compatibility: non‑RVV builds produce identical binaries.

## Checklist

- [x] Code follows the existing Snappy style.
- [x] RVV‑specific code guarded by appropriate preprocessor conditionals.
- [x] Performance data included with multiple independent observations.
- [x] Full backward compatibility maintained.
- [x] No breaking changes to API or behavior.
- [x] All existing unit tests pass.

## Screenshots

## Unit Tests - All Pass
<img width="928" height="731" alt="unittest" src="https://github.com/user-attachments/assets/5ec38ce2-49b8-42b5-891b-93311ed6681a" />

## Benchmark - Before Optimization
<img width="1393" height="3628" alt="优化前性能" src="https://github.com/user-attachments/assets/090d9884-a556-4513-b60f-c704151453df" />

## Benchmark - After Optimization
<img width="1393" height="2303" alt="优化后性能" src="https://github.com/user-attachments/assets/3d5402cf-c397-4803-9339-0f31d90f6f7e" />