### PR TITLE
RISCV: enable ExtractOffset optimization for RISC-V

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1375,7 +1375,7 @@ inline uint32_t ExtractOffset(uint32_t val, size_t tag_type) {
          reinterpret_cast<const char*>(&kExtractMasksCombined) + 2 * tag_type,
          sizeof(result));
   return val & result;
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__riscv)
   constexpr uint64_t kExtractMasksCombined = 0x0000FFFF00FF0000ull;
   return val & static_cast<uint32_t>(
       (kExtractMasksCombined >> (tag_type * 16)) & 0xFFFF);


### PR DESCRIPTION
## Summary

This PR enables the existing AArch64-specific `ExtractOffset` optimization for RISC‑V architectures. The optimization replaces a generic `memcpy`‑based mask extraction with a constant shift‑and‑mask operation, improving decompression performance on RISC‑V platforms with no code change for other architectures.

## Motivation

`ExtractOffset()` is a small but frequently called helper during Snappy decompression (`DecompressTagVariant`). On RISC‑V, the current generic path uses `memcpy` to load a 16‑bit mask from a static table, which can be slower than a simple bitwise operation – especially on in‑order RISC‑V cores where function call overhead or memory access latency matters. AArch64 already benefits from the bitwise version; extending it to RISC‑V brings the same advantage.

## Changes Made

- Modified the preprocessor condition from `#elif defined(__aarch64__)` to `#elif defined(__aarch64__) || defined(__riscv)`.
- Added no extra code – the same constant `kExtractMasksCombined = 0x0000FFFF00FF0000ull` and bit operations are now used for RISC‑V as well.
- Kept the `#else` fallback (generic `memcpy`) unchanged for all other architectures.

## Implementation Details

This PR reuses the existing AArch64 bitwise implementation. The optimized path works as follows: ...:

```cpp
constexpr uint64_t kExtractMasksCombined = 0x0000FFFF00FF0000ull;
return val & static_cast<uint32_t>(
    (kExtractMasksCombined >> (tag_type * 16)) & 0xFFFF);
```

- `kExtractMasksCombined` packs two 16‑bit masks (0xFFFF at byte offset 2‑3 and 6‑7 for little‑endian layout).
- `tag_type` is either 0 or 1, selecting the desired mask by shifting right 0 or 16 bits.
- The result is ANDed with `val` (the literal offset) to extract the correct offset bits.

This is pure integer arithmetic, avoids any memory access, and compiles to just a few RISC‑V instructions (`slli`, `srli`, `andi`). The generic `memcpy` path would typically emit a load from a literal pool or a call to `memcpy`.

## Performance Results

*Test environment:*  
- Platform: RISC‑V 64 (SpacemiT X60 @ 1.6 GHz)  
- Compiler: GCC 13.2+ with `-O3 -march=rv64gc`  
- Benchmark: snappy_benchmark

### BM_UFlat (Decompression) 

| Benchmark | Data Type | Before (MiB/s) | After (MiB/s) | Change |
|-----------|-----------|----------------|----------------|--------|
| BM_UFlat/0/2 | html | 472.8 | 498.6 | **+5.5%** |
| BM_UFlat/1/2 | urls | 267.8 | 283.4 | **+5.8%** |
| BM_UFlat/5/2 | html4 | 462.6 | 489.2 | **+5.7%** |
| BM_UFlat/10/2 | pb | 610.4 | 641.6 | **+5.1%** |
| BM_UFlatMedley | mixed | 204.3 | 216.4 | **+5.9%** |

Binary data (jpg, pdf) show <1% change, as expected.

### BM_UValidate (Validation) – Consistent improvement

| Benchmark | Data Type | Before (MiB/s) | After (MiB/s) | Change |
|-----------|-----------|----------------|----------------|--------|
| BM_UValidate/0/2 | html | 763.7 | 839.8 | **+9.9%** |
| BM_UValidate/1/2 | urls | 436.8 | 477.2 | **+9.2%** |
| BM_UValidate/5/2 | html4 | 750.2 | 828.5 | **+10.4%** |
| BM_UValidate/10/2 | pb | 1008.0 | 1082.6 | **+7.4%** |
| BM_UValidateMedley | mixed | 331.2 | 363.9 | **+9.9%** |

> Validation includes the same `ExtractOffset` path, thus similar gains.

### BM_UIOVecSource (Vectorized source read) – Mostly positive

| Benchmark | Data Type | Before (MiB/s) | After (MiB/s) | Change |
|-----------|-----------|----------------|----------------|--------|
| BM_UIOVecSource/0/2 | html | 56.64 | 56.66 | +0.0% |
| BM_UIOVecSource/5/2 | html4 | 54.21 | 55.18 | **+1.8%** |
| BM_UIOVecSource/10/2 | pb | 67.03 | 67.14 | +0.2% |
| BM_UIOVecSource/11/2 | gaviota | 33.81 | 33.82 | +0.0% |

No regressions; small improvements in some cases.

### BM_UFlatSink & BM_UIOVecSink – No meaningful change

All sink tests (write‑only) not impacted by `ExtractOffset`. Changes < ±1%, within noise.

### BM_ZFlat (Compression) – Not expected to change

`ExtractOffset` is used only during **decompression**, not compression. As expected, all ZFlat benchmarks show <0.5% variation, confirming no side effects.

### Summary of Performance Impact

- **Decompression (UFlat, UValidate)**: +5% to +10% throughput for text/html/urls/pb.
- **Vectorized read (UIOVecSource)**: Slightly positive or neutral.
- **Compression (ZFlat)**: No change (correct).
- **Sink operations**: No change.

Full benchmark suite shows **no regression** in any test.

## Compatibility and Portability

- **RISC‑V (any)** – Automatically uses the fast bitwise path. No dependency on vector extensions or specific RISC‑V version.
- **AArch64** – Unchanged, still uses the same fast path.
- **Other architectures (x86, ARM32, PowerPC, etc.)** – Continue using the generic `memcpy` fallback. Zero performance impact.

## Testing

✅ `snappy_unittest` passes all tests on RISC‑V.  
✅ `snappy_benchmark` run multiple times – results stable (<1% variation).  
✅ Verified on x86_64 (no code change there) – all tests pass.  
✅ AArch64 builds remain identical.

## Checklist

- [x] Code follows existing Snappy style (only condition change).
- [x] Architecture‑specific code guarded by `#if defined(__riscv)`.
- [x] Performance data provided (based on real hardware).
- [x] Full backward compatibility maintained.
- [x] No API or behavior changes.
- [x] All existing unit tests pass.

## Screenshots
## Unit Tests - All Pass
<img width="966" height="1083" alt="u" src="https://github.com/user-attachments/assets/0c7183e6-fb06-4050-9b40-14cc2473ce2b" />
## Benchmark - Before Optimization
<img width="1393" height="3628" alt="优化前性能" src="https://github.com/user-attachments/assets/7a82cd9b-74df-4bab-8464-9b61652640ab" />
## Benchmark - After Optimization
<img width="1380" height="3624" alt="b" src="https://github.com/user-attachments/assets/a0d40ffa-3e9b-499f-acb4-9bd49d390981" />
