### PR TITLE
Implement overflow check in MaxCompressedLength function

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -195,9 +195,9 @@ inline uint16_t* TableEntry8ByteMatch(uint16_t* table, uint64_t bytes,
 
 size_t MaxCompressedLength(size_t source_bytes) {
   // Avoid integer overflow that could cause undersized buffer allocations.
-  // Return SIZE_MAX to force a controlled allocation failure.
-  if (source_bytes > (SIZE_MAX - 32) / 7 * 6) {
-    return SIZE_MAX;
+  // Return std::numeric_limits<size_t>::max() to force a controlled allocation failure.
+  if (source_bytes > (std::numeric_limits<size_t>::max() - 32) / 7 * 6) {
+    return std::numeric_limits<size_t>::max();
   }
   // Compressed data can be defined as:
   //    compressed := item* literal*

--- a/snappy.cc
+++ b/snappy.cc
@@ -194,6 +194,11 @@ inline uint16_t* TableEntry8ByteMatch(uint16_t* table, uint64_t bytes,
 }  // namespace
 
 size_t MaxCompressedLength(size_t source_bytes) {
+  // Avoid integer overflow that could cause undersized buffer allocations.
+  // Return SIZE_MAX to force a controlled allocation failure.
+  if (source_bytes > (SIZE_MAX - 32) / 7 * 6) {
+    return SIZE_MAX;
+  }
   // Compressed data can be defined as:
   //    compressed := item* literal*
   //    item       := literal* copy

--- a/snappy.cc
+++ b/snappy.cc
@@ -74,6 +74,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>


### PR DESCRIPTION
## Summary
Add integer overflow check in `MaxCompressedLength()` to prevent
heap buffer overflow vulnerabilities.

## Problem
The expression `32 + source_bytes + source_bytes / 6` can overflow
when `source_bytes` is very large, resulting in a small return value.
Callers use this value to allocate buffers, so an overflow leads to
undersized allocations and subsequent heap buffer overflows during
compression.

## Fix
Added a bounds check before the calculation. If `source_bytes` exceeds
the safe threshold `(SIZE_MAX - 32) / 7 * 6`, the function returns
`SIZE_MAX`, which forces a controlled allocation failure instead of
silent memory corruption.