### PR TITLE
Fix -Wuninitialized-const-pointer for dummy buffer

### DIFF
--- a/snappy-test.cc
+++ b/snappy-test.cc
@@ -464,7 +464,7 @@ bool ZLib::UncompressChunkDone() {
   // Make sure we're at the end-of-compressed-data point.  This means
   // if we call inflate with Z_FINISH we won't consume any input or
   // write any output
-  Bytef dummyin, dummyout;
+  Bytef dummyin = 0, dummyout;
   uLongf dummylen = 0;
   if ( UncompressChunkOrAll(&dummyout, &dummylen, &dummyin, 0, Z_FINISH)
        != Z_OK ) {


### PR DESCRIPTION
Compiling on macOS produces a -Wuninitialized-const-pointer warning. Initialize to 0 to avoid it.

```
./snappy-test.cc:469:52: error: variable 'dummyin' is uninitialized when passed as a const pointer argument here [-Werror,-Wuninitialized-const-pointer]
  469 |   if ( UncompressChunkOrAll(&dummyout, &dummylen, &dummyin, 0, Z_FINISH)
      |                                                    ^~~~~~~
1 error generated.
```

```
% sw_vers
ProductName:		macOS
ProductVersion:		26.5.2
BuildVersion:		25F84

% clang --version
Apple clang version 21.0.0 (clang-2100.1.1.101)
Target: arm64-apple-darwin25.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```