### PR TITLE
Loop unrolling and CMOV opt for GCC on x86

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -685,7 +685,20 @@ static inline char* EmitCopyAtMost64(char* op, size_t offset, size_t len) {
     // benchmarks. This code produces branch free code, the data dependency
     // chain that bottlenecks the throughput is so long that a few extra
     // instructions are completely free (IPC << 6 because of data deps).
+#if defined(__x86_64__) && defined(__GNUC__)
+    uint32_t temp;
+    __asm__ __volatile__(
+      "cmp $2048, %1\n\t"
+      "mov %2, %0\n\t"
+      "cmovae %3, %0\n\t"
+      : "=&r"(temp)
+      : "r"(offset), "r"(copy1), "r"(copy2)
+      : "cc"
+    );
+    u += temp;
+#else
     u += offset < 2048 ? copy1 : copy2;
+#endif
     LittleEndian::Store32(op, u);
     op += offset < 2048 ? 2 : 3;
   } else {
@@ -1485,6 +1498,9 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
       // leads to reduced mov's.
 
       SNAPPY_PREFETCH(ip + 128);
+#if defined(__GNUC__)
+      #pragma GCC unroll 2
+#endif
       for (int i = 0; i < 2; i++) {
         const uint8_t* old_ip = ip;
         assert(tag == ip[-1]);


### PR DESCRIPTION
GCC does not generate the code as expected, so we added compiler hint and inline assembly to optimize it when compiling with GCC. Loop unrolling targets decompression path, while CMOV optimization targets compression path.

Performance is listed as below, compiled with GCC 12.3.0, tested on Intel EMR. This improves most of the testcase in snappy_benchmark.

  | baseline (Mi/s) | opt (Mi/s) | speedup
-- | -- | -- | --
BM_UFlat/0/1 | 2032.9472 | 2534.6458 | 24.7%
BM_UFlat/0/2 | 2270.208 | 2776.5248 | 22.3%
BM_UFlat/1/1 | 1022.58 | 1180.3136 | 15.4%
BM_UFlat/1/2 | 1104.5069 | 1273.9584 | 15.3%
BM_UFlat/2/1 | 33445.683 | 33407.283 | -0.1%
BM_UFlat/2/2 | 33659.904 | 33628.877 | -0.1%
BM_UFlat/3/1 | 1092.0448 | 1081.3235 | -1.0%
BM_UFlat/3/2 | 1141.3914 | 1131.008 | -0.9%
BM_UFlat/4/1 | 14113.28 | 14879.846 | 5.4%
BM_UFlat/4/2 | 7183.319 | 8057.4259 | 12.2%
BM_UFlat/5/1 | 1790.3309 | 2069.719 | 15.6%
BM_UFlat/5/2 | 1971.0771 | 2272.8397 | 15.3%
BM_UFlat/6/1 | 699.718 | 804.968 | 15.0%
BM_UFlat/6/2 | 783.521 | 911.488 | 16.3%
BM_UFlat/7/1 | 634.899 | 738.234 | 16.3%
BM_UFlat/7/2 | 689.441 | 806.272 | 16.9%
BM_UFlat/8/1 | 733.663 | 850.646 | 15.9%
BM_UFlat/8/2 | 835.509 | 965.665 | 15.6%
BM_UFlat/9/1 | 578.668 | 673.824 | 16.4%
BM_UFlat/9/2 | 631.183 | 714.658 | 13.2%
BM_UFlat/10/1 | 2641.3363 | 3336.2432 | 26.3%
BM_UFlat/10/2 | 2876.1498 | 3609.1187 | 25.5%
BM_UFlat/11/1 | 892.571 | 964.16 | 8.0%
BM_UFlat/11/2 | 1258.967 | 1412.0346 | 12.2%
BM_UFlatMedley | 935.186 | 1066.6086 | 14.1%
BM_UValidate/0/1 | 5130.5165 | 5136.3328 | 0.1%
BM_UValidate/0/2 | 5690.5114 | 5692.1702 | 0.0%
BM_UValidate/1/1 | 1877.2685 | 1871.1245 | -0.3%
BM_UValidate/1/2 | 2111.4778 | 2097.7357 | -0.7%
BM_UValidate/2/1 | 1238273.9 | 1218256.6 | -1.6%
BM_UValidate/2/2 | 1200797.8 | 1161434.2 | -3.3%
BM_UValidate/3/1 | 3059.8656 | 3149.9776 | 2.9%
BM_UValidate/3/2 | 3311.8413 | 3326.4845 | 0.4%
BM_UValidate/4/1 | 52408.115 | 52382.208 | 0.0%
BM_UValidate/4/2 | 18199.245 | 18218.189 | 0.1%
BM_UValidate/5/1 | 5069.5168 | 5081.1187 | 0.2%
BM_UValidate/5/2 | 5660.5491 | 5670.4307 | 0.2%
BM_UValidate/6/1 | 1650.3194 | 1632.8192 | -1.1%
BM_UValidate/6/2 | 1877.0739 | 1902.1107 | 1.3%
BM_UValidate/7/1 | 1592.873 | 1562.3475 | -1.9%
BM_UValidate/7/2 | 1744.9165 | 1736.4992 | -0.5%
BM_UValidate/8/1 | 1298.135 | 1300.3981 | 0.2%
BM_UValidate/8/2 | 1483.1923 | 1489.2749 | 0.4%
BM_UValidate/9/1 | 983.531 | 980.103 | -0.3%
BM_UValidate/9/2 | 1066.7315 | 1063.6186 | -0.3%
BM_UValidate/10/1 | 6843.7709 | 6831.6877 | -0.2%
BM_UValidate/10/2 | 7502.7661 | 7496.233 | -0.1%
BM_UValidate/11/1 | 2142.9248 | 2152.0077 | 0.4%
BM_UValidate/11/2 | 2788.0653 | 2807.2653 | 0.7%
BM_UValidateMedley | 1622.8557 | 1617.7152 | -0.3%
BM_UIOVecSource/0/1 | 1319.5366 | 1648.3328 | 24.9%
BM_UIOVecSource/0/2 | 903.611 | 860.563 | -4.8%
BM_UIOVecSource/1/1 | 454.673 | 458.37 | 0.8%
BM_UIOVecSource/1/2 | 363.088 | 372.682 | 2.6%
BM_UIOVecSource/2/1 | 11148.595 | 11308.544 | 1.4%
BM_UIOVecSource/2/2 | 2765.7626 | 2792.3354 | 1.0%
BM_UIOVecSource/3/1 | 704.915 | 710.427 | 0.8%
BM_UIOVecSource/3/2 | 485.706 | 482.834 | -0.6%
BM_UIOVecSource/4/1 | 7492.137 | 7483.4842 | -0.1%
BM_UIOVecSource/4/2 | 644.418 | 635.649 | -1.4%
BM_UIOVecSource/5/1 | 922.593 | 972.878 | 5.5%
BM_UIOVecSource/5/2 | 711.928 | 712.212 | 0.0%
BM_UIOVecSource/6/1 | 323.591 | 350.119 | 8.2%
BM_UIOVecSource/6/2 | 224.308 | 237.92 | 6.1%
BM_UIOVecSource/7/1 | 307.441 | 322.881 | 5.0%
BM_UIOVecSource/7/2 | 209.537 | 221.05 | 5.5%
BM_UIOVecSource/8/1 | 314.464 | 336.361 | 7.0%
BM_UIOVecSource/8/2 | 228.62 | 240.097 | 5.0%
BM_UIOVecSource/9/1 | 254.757 | 270.56 | 6.2%
BM_UIOVecSource/9/2 | 187.408 | 195.437 | 4.3%
BM_UIOVecSource/10/1 | 2116.4339 | 2132.0499 | 0.7%
BM_UIOVecSource/10/2 | 1380.0141 | 1393.2339 | 1.0%
BM_UIOVecSource/11/1 | 523.238 | 569.949 | 8.9%
BM_UIOVecSource/11/2 | 348.805 | 366.633 | 5.1%
BM_UIOVecSink/0 | 1306.665 | 1310.249 | 0.3%
BM_UIOVecSink/1 | 786.737 | 788.347 | 0.2%
BM_UIOVecSink/2 | 33287.782 | 33406.874 | 0.4%
BM_UIOVecSink/3 | 843.92 | 851.756 | 0.9%
BM_UIOVecSink/4 | 13507.891 | 13490.483 | -0.1%
BM_UFlatSink/0/1 | 2037.2685 | 2529.6282 | 24.2%
BM_UFlatSink/0/2 | 2263.4086 | 2803.5891 | 23.9%
BM_UFlatSink/1/1 | 1022.26 | 1180.4262 | 15.5%
BM_UFlatSink/1/2 | 1112.9242 | 1270.2413 | 14.1%
BM_UFlatSink/2/1 | 33837.568 | 34010.419 | 0.5%
BM_UFlatSink/2/2 | 34180.71 | 34315.162 | 0.4%
BM_UFlatSink/3/1 | 1079.255 | 1073.6947 | -0.5%
BM_UFlatSink/3/2 | 1141.1558 | 1122.3859 | -1.6%
BM_UFlatSink/4/1 | 13839.462 | 14874.931 | 7.5%
BM_UFlatSink/4/2 | 7183.4931 | 7994.7674 | 11.3%
BM_UFlatSink/5/1 | 1789.3478 | 2074.0301 | 15.9%
BM_UFlatSink/5/2 | 1960.4582 | 2231.511 | 13.8%
BM_UFlatSink/6/1 | 693.799 | 798.932 | 15.2%
BM_UFlatSink/6/2 | 777.808 | 901.614 | 15.9%
BM_UFlatSink/7/1 | 634.636 | 734.321 | 15.7%
BM_UFlatSink/7/2 | 694.854 | 802.622 | 15.5%
BM_UFlatSink/8/1 | 732.629 | 845.72 | 15.4%
BM_UFlatSink/8/2 | 836.698 | 959.819 | 14.7%
BM_UFlatSink/9/1 | 578.86 | 664.108 | 14.7%
BM_UFlatSink/9/2 | 627.884 | 722.19 | 15.0%
BM_UFlatSink/10/1 | 2640.8038 | 3360.0307 | 27.2%
BM_UFlatSink/10/2 | 2851.5226 | 3673.5386 | 28.8%
BM_UFlatSink/11/1 | 884.431 | 960.729 | 8.6%
BM_UFlatSink/11/2 | 1245.3683 | 1406.0954 | 12.9%
BM_ZFlat/0/1 | 1377.6794 | 1749.0739 | 27.0%
BM_ZFlat/0/2 | 921.874 | 890.74 | -3.4%
BM_ZFlat/1/1 | 456.744 | 463.623 | 1.5%
BM_ZFlat/1/2 | 364.852 | 376.263 | 3.1%
BM_ZFlat/2/1 | 17156.915 | 17183.539 | 0.2%
BM_ZFlat/2/2 | 3036.8256 | 3045.2429 | 0.3%
BM_ZFlat/3/1 | 880.098 | 878.52 | -0.2%
BM_ZFlat/3/2 | 556.329 | 553.342 | -0.5%
BM_ZFlat/4/1 | 9620.3776 | 9642.1581 | 0.2%
BM_ZFlat/4/2 | 656.688 | 651.714 | -0.8%
BM_ZFlat/5/1 | 958.127 | 1008.27 | 5.2%
BM_ZFlat/5/2 | 730.147 | 732.699 | 0.3%
BM_ZFlat/6/1 | 330.064 | 354.049 | 7.3%
BM_ZFlat/6/2 | 225.121 | 239.777 | 6.5%
BM_ZFlat/7/1 | 307.864 | 326.538 | 6.1%
BM_ZFlat/7/2 | 211.31 | 222.928 | 5.5%
BM_ZFlat/8/1 | 318.564 | 339.275 | 6.5%
BM_ZFlat/8/2 | 230.153 | 241.561 | 5.0%
BM_ZFlat/9/1 | 256.46 | 272.703 | 6.3%
BM_ZFlat/9/2 | 187.632 | 196.492 | 4.7%
BM_ZFlat/10/1 | 2295.6646 | 2301.1328 | 0.2%
BM_ZFlat/10/2 | 1446.697 | 1455.6058 | 0.6%
BM_ZFlat/11/1 | 532.88 | 582.802 | 9.4%
BM_ZFlat/11/2 | 352.101 | 371.854 | 5.6%
BM_ZFlatAll/1 | 410.864 | 431.626 | 5.1%
BM_ZFlatAll/2 | 304.827 | 318.23 | 4.4%
BM_ZFlatIncreasingTableSize/1 | 1307.6992 | 1307.7709 | 0.0%
BM_ZFlatIncreasingTableSize/2 | 857.316 | 860.117 | 0.3%

Improvement is also observed on our Hygon CPU.