### PR TITLE
Loop unrolling and CMOV opt for GCC on x86

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -685,9 +685,26 @@ static inline char* EmitCopyAtMost64(char* op, size_t offset, size_t len) {
     // benchmarks. This code produces branch free code, the data dependency
     // chain that bottlenecks the throughput is so long that a few extra
     // instructions are completely free (IPC << 6 because of data deps).
+#if defined(__x86_64__) && defined(__GNUC__)
+    uint32_t temp;
+    char* op_ = op;
+    __asm__ __volatile__(
+      "cmp $2048, %2\n\t"
+      "mov %3, %0\n\t"		// temp = copy1
+      "cmovae %4, %0\n\t"	// temp = copy2 if (offset < 2048), cover copy1
+      "sbb $0, %1\n\t"		// op -= 1 if (offset < 2048), reuse CF
+      "add $3, %1\n\t"		// op += 3
+      : "=&r"(temp), "+&r"(op)
+      : "r"(offset), "r"(copy1), "r"(copy2)
+      : "cc"
+    );
+    u += temp;
+    LittleEndian::Store32(op_, u);
+#else
     u += offset < 2048 ? copy1 : copy2;
     LittleEndian::Store32(op, u);
     op += offset < 2048 ? 2 : 3;
+#endif
   } else {
     // Write 4 bytes, though we only care about 3 of them.  The output buffer
     // is required to have some slack, so the extra byte won't overrun it.
@@ -1485,6 +1502,9 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
       // leads to reduced mov's.
 
       SNAPPY_PREFETCH(ip + 128);
+#if defined(__GNUC__)
+      #pragma GCC unroll 2
+#endif
       for (int i = 0; i < 2; i++) {
         const uint8_t* old_ip = ip;
         assert(tag == ip[-1]);


### PR DESCRIPTION
GCC does not generate the code as expected, so we add compiler hint and inline assembly to optimize it when compiling with GCC.

Performance is listed as below, compiled with GCC 12.3.0, tested on Intel EMR. This improves most of the testcase in snappy_benchmark.

  | baseline (Mi/s) | opt (Mi/s) | speedup
-- | -- | -- | --
BM_UFlat/0/1 | 2032.9472 | 2641.0086 | 29.91%
BM_UFlat/0/2 | 2270.208 | 2889.0931 | 27.26%
BM_UFlat/1/1 | 1022.58 | 1205.1046 | 17.85%
BM_UFlat/1/2 | 1104.5069 | 1297.0291 | 17.43%
BM_UFlat/2/1 | 33445.683 | 33405.44 | -0.12%
BM_UFlat/2/2 | 33659.904 | 33633.894 | -0.08%
BM_UFlat/3/1 | 1092.0448 | 1080.1254 | -1.09%
BM_UFlat/3/2 | 1141.3914 | 1125.417 | -1.40%
BM_UFlat/4/1 | 14113.28 | 15238.349 | 7.97%
BM_UFlat/4/2 | 7183.319 | 8174.1517 | 13.79%
BM_UFlat/5/1 | 1790.3309 | 2124.6259 | 18.67%
BM_UFlat/5/2 | 1971.0771 | 2301.9213 | 16.78%
BM_UFlat/6/1 | 699.718 | 815.863 | 16.60%
BM_UFlat/6/2 | 783.521 | 916.886 | 17.02%
BM_UFlat/7/1 | 634.899 | 748.96 | 17.97%
BM_UFlat/7/2 | 689.441 | 815.408 | 18.27%
BM_UFlat/8/1 | 733.663 | 870.94 | 18.71%
BM_UFlat/8/2 | 835.509 | 991.6 | 18.68%
BM_UFlat/9/1 | 578.668 | 679.639 | 17.45%
BM_UFlat/9/2 | 631.183 | 739.369 | 17.14%
BM_UFlat/10/1 | 2641.3363 | 3416.7296 | 29.36%
BM_UFlat/10/2 | 2876.1498 | 3790.2029 | 31.78%
BM_UFlat/11/1 | 892.571 | 985.461 | 10.41%
BM_UFlat/11/2 | 1258.967 | 1454.4077 | 15.52%
BM_UFlatMedley | 935.186 | 1081.9482 | 15.69%
BM_UValidate/0/1 | 5130.5165 | 5137.1622 | 0.13%
BM_UValidate/0/2 | 5690.5114 | 5697.7408 | 0.13%
BM_UValidate/1/1 | 1877.2685 | 1883.4944 | 0.33%
BM_UValidate/1/2 | 2111.4778 | 2049.9763 | -2.91%
BM_UValidate/2/1 | 1238273.9 | 1225030.4 | -1.07%
BM_UValidate/2/2 | 1200797.8 | 1209039.6 | 0.69%
BM_UValidate/3/1 | 3059.8656 | 3089.8074 | 0.98%
BM_UValidate/3/2 | 3311.8413 | 3271.8746 | -1.21%
BM_UValidate/4/1 | 52408.115 | 52378.317 | -0.06%
BM_UValidate/4/2 | 18199.245 | 18166.272 | -0.18%
BM_UValidate/5/1 | 5069.5168 | 5066.5165 | -0.06%
BM_UValidate/5/2 | 5660.5491 | 5640.5197 | -0.35%
BM_UValidate/6/1 | 1650.3194 | 1644.0934 | -0.38%
BM_UValidate/6/2 | 1877.0739 | 1884.7539 | 0.41%
BM_UValidate/7/1 | 1592.873 | 1561.3542 | -1.98%
BM_UValidate/7/2 | 1744.9165 | 1747.9373 | 0.17%
BM_UValidate/8/1 | 1298.135 | 1297.1622 | -0.07%
BM_UValidate/8/2 | 1483.1923 | 1481.4515 | -0.12%
BM_UValidate/9/1 | 983.531 | 977.152 | -0.65%
BM_UValidate/9/2 | 1066.7315 | 1080.4838 | 1.29%
BM_UValidate/10/1 | 6843.7709 | 6834.5958 | -0.13%
BM_UValidate/10/2 | 7502.7661 | 7505.9098 | 0.04%
BM_UValidate/11/1 | 2142.9248 | 2137.385 | -0.26%
BM_UValidate/11/2 | 2788.0653 | 2760.2432 | -1.00%
BM_UValidateMedley | 1622.8557 | 1632.215 | 0.58%
BM_UIOVecSource/0/1 | 1319.5366 | 1629.3274 | 23.48%
BM_UIOVecSource/0/2 | 903.611 | 969.112 | 7.25%
BM_UIOVecSource/1/1 | 454.673 | 451.702 | -0.65%
BM_UIOVecSource/1/2 | 363.088 | 377.114 | 3.86%
BM_UIOVecSource/2/1 | 11148.595 | 11317.146 | 1.51%
BM_UIOVecSource/2/2 | 2765.7626 | 2824.0691 | 2.11%
BM_UIOVecSource/3/1 | 704.915 | 732.726 | 3.95%
BM_UIOVecSource/3/2 | 485.706 | 493.211 | 1.55%
BM_UIOVecSource/4/1 | 7492.137 | 7444.4186 | -0.64%
BM_UIOVecSource/4/2 | 644.418 | 645.378 | 0.15%
BM_UIOVecSource/5/1 | 922.593 | 977.29 | 5.93%
BM_UIOVecSource/5/2 | 711.928 | 763.236 | 7.21%
BM_UIOVecSource/6/1 | 323.591 | 350.532 | 8.33%
BM_UIOVecSource/6/2 | 224.308 | 236.428 | 5.40%
BM_UIOVecSource/7/1 | 307.441 | 324.772 | 5.64%
BM_UIOVecSource/7/2 | 209.537 | 221.037 | 5.49%
BM_UIOVecSource/8/1 | 314.464 | 335.48 | 6.68%
BM_UIOVecSource/8/2 | 228.62 | 241.01 | 5.42%
BM_UIOVecSource/9/1 | 254.757 | 271.373 | 6.52%
BM_UIOVecSource/9/2 | 187.408 | 195.101 | 4.10%
BM_UIOVecSource/10/1 | 2116.4339 | 2133.4733 | 0.81%
BM_UIOVecSource/10/2 | 1380.0141 | 1501.8189 | 8.83%
BM_UIOVecSource/11/1 | 523.238 | 579.024 | 10.66%
BM_UIOVecSource/11/2 | 348.805 | 377.893 | 8.34%
BM_UIOVecSink/0 | 1306.665 | 1477.5808 | 13.08%
BM_UIOVecSink/1 | 786.737 | 790.53 | 0.48%
BM_UIOVecSink/2 | 33287.782 | 33342.157 | 0.16%
BM_UIOVecSink/3 | 843.92 | 849.994 | 0.72%
BM_UIOVecSink/4 | 13507.891 | 13605.274 | 0.72%
BM_UFlatSink/0/1 | 2037.2685 | 2625.7715 | 28.89%
BM_UFlatSink/0/2 | 2263.4086 | 2876.0166 | 27.07%
BM_UFlatSink/1/1 | 1022.26 | 1203.1283 | 17.69%
BM_UFlatSink/1/2 | 1112.9242 | 1296.8653 | 16.53%
BM_UFlatSink/2/1 | 33837.568 | 33957.99 | 0.36%
BM_UFlatSink/2/2 | 34180.71 | 34301.338 | 0.35%
BM_UFlatSink/3/1 | 1079.255 | 1074.0224 | -0.48%
BM_UFlatSink/3/2 | 1141.1558 | 1122.9491 | -1.60%
BM_UFlatSink/4/1 | 13839.462 | 15205.069 | 9.87%
BM_UFlatSink/4/2 | 7183.4931 | 8040.6016 | 11.93%
BM_UFlatSink/5/1 | 1789.3478 | 2110.7917 | 17.96%
BM_UFlatSink/5/2 | 1960.4582 | 2332.8666 | 19.00%
BM_UFlatSink/6/1 | 693.799 | 813.743 | 17.29%
BM_UFlatSink/6/2 | 777.808 | 915.081 | 17.65%
BM_UFlatSink/7/1 | 634.636 | 742.015 | 16.92%
BM_UFlatSink/7/2 | 694.854 | 819.602 | 17.95%
BM_UFlatSink/8/1 | 732.629 | 866.121 | 18.22%
BM_UFlatSink/8/2 | 836.698 | 987.365 | 18.01%
BM_UFlatSink/9/1 | 578.86 | 677.048 | 16.96%
BM_UFlatSink/9/2 | 627.884 | 735.186 | 17.09%
BM_UFlatSink/10/1 | 2640.8038 | 3476.1523 | 31.63%
BM_UFlatSink/10/2 | 2851.5226 | 3744.727 | 31.32%
BM_UFlatSink/11/1 | 884.431 | 983.786 | 11.23%
BM_UFlatSink/11/2 | 1245.3683 | 1449.8714 | 16.42%
BM_ZFlat/0/1 | 1377.6794 | 1730.9491 | 25.64%
BM_ZFlat/0/2 | 921.874 | 996.807 | 8.13%
BM_ZFlat/1/1 | 456.744 | 458.386 | 0.36%
BM_ZFlat/1/2 | 364.852 | 380.741 | 4.35%
BM_ZFlat/2/1 | 17156.915 | 17176.064 | 0.11%
BM_ZFlat/2/2 | 3036.8256 | 3050.8646 | 0.46%
BM_ZFlat/3/1 | 880.098 | 874.765 | -0.61%
BM_ZFlat/3/2 | 556.329 | 554.738 | -0.29%
BM_ZFlat/4/1 | 9620.3776 | 9708.1344 | 0.91%
BM_ZFlat/4/2 | 656.688 | 656.126 | -0.09%
BM_ZFlat/5/1 | 958.127 | 1004.12 | 4.80%
BM_ZFlat/5/2 | 730.147 | 778.919 | 6.68%
BM_ZFlat/6/1 | 330.064 | 356.579 | 8.03%
BM_ZFlat/6/2 | 225.121 | 238.582 | 5.98%
BM_ZFlat/7/1 | 307.864 | 327.051 | 6.23%
BM_ZFlat/7/2 | 211.31 | 223.18 | 5.62%
BM_ZFlat/8/1 | 318.564 | 339.028 | 6.42%
BM_ZFlat/8/2 | 230.153 | 242.178 | 5.22%
BM_ZFlat/9/1 | 256.46 | 273.18 | 6.52%
BM_ZFlat/9/2 | 187.632 | 196.124 | 4.53%
BM_ZFlat/10/1 | 2295.6646 | 2307.2358 | 0.50%
BM_ZFlat/10/2 | 1446.697 | 1587.4867 | 9.73%
BM_ZFlat/11/1 | 532.88 | 592.854 | 11.25%
BM_ZFlat/11/2 | 352.101 | 383.928 | 9.04%
BM_ZFlatAll/1 | 410.864 | 430.215 | 4.71%
BM_ZFlatAll/2 | 304.827 | 316.429 | 3.81%
BM_ZFlatIncreasingTableSize/1 | 1307.6992 | 1296.4045 | -0.86%
BM_ZFlatIncreasingTableSize/2 | 857.316 | 829.6 | -3.23%