### PR TITLE
Fall back to level-1 compressor for unsupported compression levels

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1886,7 +1886,9 @@ size_t Compress(Source* reader, Sink* writer) {
 static size_t InternalCompress(Source* reader, Sink* writer,
                                CompressionOptions options,
                                internal::WorkingMemory* wmem) {
-  assert(options.level == 1 || options.level == 2);
+  // Levels other than 1 and 2 are not implemented yet and are handled by the
+  // fallback below.
+  assert(options.level >= 1);
   size_t written = 0;
   size_t N = reader->Available();
   assert(N <= 0xFFFFFFFFu);
@@ -1939,15 +1941,18 @@ static size_t InternalCompress(Source* reader, Sink* writer,
     // Need a scratch buffer for the output, in case the byte sink doesn't
     // have room for us directly.
     char* dest = writer->GetAppendBuffer(max_output, wmem->GetScratchOutput());
-    char* end = nullptr;
-      if (options.level == 1) {
-        end = internal::CompressFragment(fragment, fragment_size, dest, table,
-                                         table_size);
-      } else if (options.level == 2) {
-        end = internal::CompressFragmentDoubleHash(
-            fragment, fragment_size, dest, table, table_size >> 1,
-            table + (table_size >> 1), table_size >> 1);
-      }
+    char* end;
+    if (options.level == 2) {
+      end = internal::CompressFragmentDoubleHash(
+          fragment, fragment_size, dest, table, table_size >> 1,
+          table + (table_size >> 1), table_size >> 1);
+    } else {
+      // Level 1 is the default, and levels above 2 are not implemented yet.
+      // CompressionOptions does not reject them, so fall back to the level-1
+      // compressor instead of leaving `end` uninitialized.
+      end = internal::CompressFragment(fragment, fragment_size, dest, table,
+                                       table_size);
+    }
 
     writer->Append(dest, end - dest);
     written += (end - dest);

--- a/snappy_unittest.cc
+++ b/snappy_unittest.cc
@@ -647,6 +647,35 @@ TEST(Snappy, CompressionContextStaticWorkspace) {
   EXPECT_EQ(a, b);
 }
 
+TEST(Snappy, UnsupportedCompressionLevels) {
+  // CompressionOptions accepts any level, but only levels 1 and 2 are
+  // implemented. Unsupported levels must fall back to the default (level 1)
+  // compressor instead of producing an invalid result.
+  std::string input = "some data to compress, and then some more data";
+  input += input + input + input;
+
+  std::string baseline;
+  size_t baseline_len = snappy::Compress(input.data(), input.size(), &baseline,
+                                         CompressionOptions{1});
+  ASSERT_EQ(baseline_len, baseline.size());
+
+  for (int level = CompressionOptions::MaxCompressionLevel() + 1; level <= 9;
+       ++level) {
+    std::string compressed;
+    size_t compressed_len =
+        snappy::Compress(input.data(), input.size(), &compressed,
+                         CompressionOptions{level});
+    ASSERT_EQ(compressed_len, compressed.size());
+    EXPECT_EQ(baseline, compressed) << "level=" << level;
+
+    std::string uncompressed;
+    EXPECT_TRUE(snappy::Uncompress(compressed.data(), compressed.size(),
+                                   &uncompressed))
+        << "level=" << level;
+    EXPECT_EQ(input, uncompressed) << "level=" << level;
+  }
+}
+
 TEST(Snappy, FourByteOffset) {
   // The new compressor cannot generate four-byte offsets since
   // it chops up the input into 32KB pieces.  So we hand-emit the


### PR DESCRIPTION
## What

`CompressionOptions` is constructible with any `int` compression level, and `snappy.cc` documents levels 3+ as "currently not supported" rather than rejecting them. In `InternalCompress`, the level dispatch only set `end` for levels 1 and 2; for any other level `end` stayed `nullptr`, and `writer->Append(dest, end - dest)` then computed a garbage length from undefined behaviour. The string-based `Compress()` path would throw `std::out_of_range` from `std::string::erase`, and the raw path wrote through a wild pointer.

This only manifests with levels outside `[1, 2]`, so the fuzzers (which iterate levels 1..2) never hit it.

## Fix

Treat every level other than 2 as the default (level 1) compressor instead of leaving `end` uninitialized. The existing `assert(options.level == 1 || options.level == 2)` was relaxed to `assert(options.level >= 1)` to match the new tolerant dispatch.

## Test

Added `Snappy.UnsupportedCompressionLevels`, which compresses with levels 3..9, asserts the output matches the level-1 baseline, and round-trips through `Uncompress`. Full suite passes in Debug and Release (25/25).