### PR TITLE
Honor CMAKE_INSTALL_INCLUDEDIR in exported header paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,9 @@ configure_file(
   "snappy-stubs-public.h.in"
   "${PROJECT_BINARY_DIR}/snappy-stubs-public.h")
 
+# Must be included before CMAKE_INSTALL_INCLUDEDIR is used.
+include(GNUInstallDirs)
+
 add_library(snappy "")
 target_sources(snappy
   PRIVATE
@@ -298,19 +301,19 @@ target_sources(snappy
     "${PROJECT_BINARY_DIR}/config.h"
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/snappy-c.h>
-    $<INSTALL_INTERFACE:include/snappy-c.h>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/snappy-c.h>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/snappy-sinksource.h>
-    $<INSTALL_INTERFACE:include/snappy-sinksource.h>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/snappy-sinksource.h>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/snappy.h>
-    $<INSTALL_INTERFACE:include/snappy.h>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/snappy.h>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/snappy-stubs-public.h>
-    $<INSTALL_INTERFACE:include/snappy-stubs-public.h>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/snappy-stubs-public.h>
 )
 target_include_directories(snappy
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 set_target_properties(snappy
   PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
@@ -433,9 +436,6 @@ if(SNAPPY_FUZZING_BUILD)
     PROPERTIES LINK_FLAGS "-fsanitize=fuzzer"
   )
 endif(SNAPPY_FUZZING_BUILD)
-
-# Must be included before CMAKE_INSTALL_INCLUDEDIR is used.
-include(GNUInstallDirs)
 
 if(SNAPPY_INSTALL)
   install(TARGETS snappy


### PR DESCRIPTION
Fixes #206.

The install rules honor `CMAKE_INSTALL_INCLUDEDIR`, but the exported target still
points its public header sources and include directory at `<prefix>/include`.
An external CMake consumer therefore fails to configure when headers are
installed in a separate prefix or a custom relative directory.

Use `CMAKE_INSTALL_INCLUDEDIR` for those exported paths and load GNUInstallDirs
before constructing the target. This preserves the default layout and relative
path relocation without dropping the public header sources.

Verified the original failure with an installed-package consumer. After the
change, that consumer builds and roundtrips data with default, custom relative,
absolute split-prefix, relocated default, and shared-library split-prefix
installations. All 25 unit tests and a shortened run of all benchmarks pass
with GCC 15.2 and CMake 3.31.6 on Linux.

AI assistance was used to prepare this patch and run local validation.
