### PR TITLE
perf: inline branchless decompression helpers (fixes #251)

### DIFF
--- a/snappy.cc
+++ b/snappy.cc
@@ -1246,7 +1246,8 @@ inline bool Copy64BytesWithPatternExtension(ptrdiff_t dst, size_t offset) {
 // 64.  More than size bytes, but never exceeding 64, might be copied if doing
 // so gives better performance.  [src, src + size) must not overlap with
 // [dst, dst + size), but [src, src + 64) may overlap with [dst, dst + 64).
-void MemCopy64(char* dst, const void* src, size_t size) {
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline void MemCopy64(char* dst, const void* src, size_t size) {
   // Always copy this many bytes.  If that's below size then copy the full 64.
   constexpr int kShortMemCopy = 32;
   (void)kShortMemCopy;
@@ -1300,20 +1301,23 @@ void MemCopy64(char* dst, const void* src, size_t size) {
 #endif
 }
 
-void MemCopy64(ptrdiff_t dst, const void* src, size_t size) {
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline void MemCopy64(ptrdiff_t dst, const void* src, size_t size) {
   // TODO: Switch to [[maybe_unused]] when we can assume C++17.
   (void)dst;
   (void)src;
   (void)size;
 }
 
-void ClearDeferred(const void** deferred_src, size_t* deferred_length,
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline void ClearDeferred(const void** deferred_src, size_t* deferred_length,
                    uint8_t* safe_source) {
   *deferred_src = safe_source;
   *deferred_length = 0;
 }
 
-void DeferMemCopy(const void** deferred_src, size_t* deferred_length,
+SNAPPY_ATTRIBUTE_ALWAYS_INLINE
+inline void DeferMemCopy(const void** deferred_src, size_t* deferred_length,
                   const void* src, size_t length) {
   *deferred_src = src;
   *deferred_length = length;


### PR DESCRIPTION
### Summary of changes

When building Snappy as a shared library (`BUILD_SHARED_LIBS=ON`) under GCC (e.g. GCC 10/12 on AArch64 and other platforms), small helpers in the branchless decompression path (`MemCopy64`, `ClearDeferred`, `DeferMemCopy`) were not automatically inlined by GCC, resulting in PLT overhead within the tight decompression loop.

Following the guidance in #251, this patch adds `SNAPPY_ATTRIBUTE_ALWAYS_INLINE inline` annotations to:
- `MemCopy64(char* dst, const void* src, size_t size)`
- `MemCopy64(ptrdiff_t dst, const void* src, size_t size)`
- `ClearDeferred(const void** deferred_src, size_t* deferred_length, uint8_t* safe_source)`
- `DeferMemCopy(const void** deferred_src, size_t* deferred_length, const void* src, size_t length)`

Matching the existing pattern used by `AdvanceToNextTagARMOptimized` and related functions.

### Benchmark Impact
As benchmarked in #251, inlining these helpers yields significant throughput gains under GCC shared builds:
- `BM_UFlatMedley`: +12.5% to +14.0%
- `BM_UValidateMedley`: +44.6% to +49.2%
- Real-world datasets (Silesia, itemdata): +12.4% to +16.0%

Fixes #251
