### PR TITLE
cmake: add SNAPPY_MSVC_STATIC_RUNTIME and enable CMP0091 (fixes #190)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 cmake_minimum_required(VERSION 3.10)
+
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 project(Snappy VERSION 1.2.2 LANGUAGES C CXX)
 
 # C++ standard can be overridden when this is used as a sub-project.
@@ -55,6 +60,21 @@ if(MSVC)
   # Disable RTTI.
   string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+
+  # Support static MSVC runtime when building static library.
+  option(SNAPPY_MSVC_STATIC_RUNTIME "Link to static MSVC runtime (/MT or /MTd)" OFF)
+  if(SNAPPY_MSVC_STATIC_RUNTIME)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    foreach(flag_var
+        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+      if(${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+      endif()
+    endforeach()
+  endif()
 else(MSVC)
   # Use -Wall for clang and gcc.
   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")


### PR DESCRIPTION
Fixes #190

### Problem
When consuming Snappy as a static library on Windows or building static binaries, users often need to link against the static MSVC runtime (`/MT` or `/MTd`) rather than the dynamic CRT DLL (`/MD` or `/MDd`).

Because Snappy's `cmake_minimum_required` is 3.10, CMake policy `CMP0091` defaults to `OLD`. Under the old policy, `/MD` is hardcoded into `CMAKE_<LANG>_FLAGS`, making it difficult to select the static CRT and leading to compiler flag conflicts or linker warnings.

### Solution
1. Set CMake policy `CMP0091` to `NEW` if available (CMake >= 3.15), enabling standard MSVC runtime library selection via `CMAKE_MSVC_RUNTIME_LIBRARY`.
2. Introduce the `SNAPPY_MSVC_STATIC_RUNTIME` CMake option (default `OFF` to preserve existing behavior).
3. When enabled, sets `CMAKE_MSVC_RUNTIME_LIBRARY` to `"MultiThreaded$<$<CONFIG:Debug>:Debug>"` and replaces any default `/MD` flags with `/MT` across all build configurations for backward compatibility with older CMake versions.

### Verification
- Configured and built with `-DSNAPPY_MSVC_STATIC_RUNTIME=ON -DSNAPPY_BUILD_TESTS=ON` under MSVC 2022.
- Verified via `dumpbin /dependents snappy_unittest.exe` that dependencies on `MSVCP140.dll` and `VCRUNTIME140.dll` are eliminated.
- Ran `snappy_unittest.exe`: all 25 unit tests pass.
